### PR TITLE
Workflow no calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "error-trace",
  "humanlog",
  "log",
+ "num-traits",
  "serde",
  "serde_json",
  "specifications",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
+source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
 dependencies = [
  "brane-dsl",
  "brane-shr",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
+source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
 dependencies = [
  "brane-shr",
  "bytes",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
+source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
 dependencies = [
  "async-compression",
  "console",
@@ -592,9 +592,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.6.0+2.2.0"
+version = "4.7.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad63c279fca41a27c231c450a2d2ad18288032e9cbb159ad16c9d96eba35aaaf"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
 dependencies = [
  "cmake",
  "libc",
@@ -1835,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
+source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f106dcc4402d767f408513006040935e521e9ee4"
+source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
 dependencies = [
  "brane-dsl",
  "brane-shr",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f106dcc4402d767f408513006040935e521e9ee4"
+source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
 dependencies = [
  "brane-shr",
  "bytes",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f106dcc4402d767f408513006040935e521e9ee4"
+source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
 dependencies = [
  "async-compression",
  "console",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f106dcc4402d767f408513006040935e521e9ee4"
+source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2599,6 +2599,7 @@ dependencies = [
  "error-trace",
  "humanlog",
  "log",
+ "serde",
  "serde_json",
  "specifications",
  "transform",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
+source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
 dependencies = [
  "brane-dsl",
  "brane-shr",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
+source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
 dependencies = [
  "brane-shr",
  "bytes",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
+source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
 dependencies = [
  "async-compression",
  "console",
@@ -1228,9 +1228,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.58"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1260,9 +1260,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.94"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#aef9f98f50723ed16468433aeee3fa842b7713e8"
+source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
+source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
 dependencies = [
  "brane-dsl",
  "brane-shr",
@@ -247,13 +247,14 @@ dependencies = [
  "serde",
  "serde_json_any_key",
  "specifications",
+ "strum 0.25.0",
  "uuid",
 ]
 
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
+source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
 dependencies = [
  "brane-shr",
  "bytes",
@@ -274,7 +275,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
+source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
 dependencies = [
  "async-compression",
  "console",
@@ -377,7 +378,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -499,7 +500,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -510,7 +511,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -701,7 +702,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1042,9 +1043,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libz-sys"
@@ -1249,7 +1250,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1316,7 +1317,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1656,22 +1657,22 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1703,7 +1704,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1753,7 +1754,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1834,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#d4a72a806f3b11b57c760c341d8260c045dd1651"
+source = "git+https://github.com/epi-project/brane?branch=develop#e8ab64357b3a9d8fe638d7473284202fdf01f257"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,8 +1856,8 @@ dependencies = [
  "serde_test",
  "serde_with",
  "serde_yaml",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "tonic",
  "uuid",
 ]
@@ -1874,6 +1875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1894,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1899,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1965,7 +1988,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2046,7 +2069,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2195,7 +2218,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2338,7 +2361,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -2372,7 +2395,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2571,9 +2594,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
+source = "git+https://github.com/epi-project/brane?branch=develop#c6996808ffdfce66d46842badc97bb696b5f061e"
 dependencies = [
  "brane-dsl",
  "brane-shr",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
+source = "git+https://github.com/epi-project/brane?branch=develop#c6996808ffdfce66d46842badc97bb696b5f061e"
 dependencies = [
  "brane-shr",
  "bytes",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
+source = "git+https://github.com/epi-project/brane?branch=develop#c6996808ffdfce66d46842badc97bb696b5f061e"
 dependencies = [
  "async-compression",
  "console",
@@ -284,6 +284,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
+ "humanlog",
  "indicatif",
  "log",
  "num-derive",
@@ -1835,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane?branch=develop#f8aea3194b3886443886daaf459b435bd6172a84"
+source = "git+https://github.com/epi-project/brane?branch=develop#c6996808ffdfce66d46842badc97bb696b5f061e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -26,3 +26,7 @@ log = "0.4"
 serde_json = "1.0"
 
 brane-shr = { git = "https://github.com/epi-project/brane", branch = "develop" }
+
+
+[features]
+"eflint" = []

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 transform = { git = "https://github.com/Lut99/transform-rs" }
 
 brane-ast = { git = "https://github.com/epi-project/brane", branch = "develop" }

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
 log = "0.4"
+num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 transform = { git = "https://github.com/Lut99/transform-rs" }
 

--- a/lib/workflow/src/compile.rs
+++ b/lib/workflow/src/compile.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 17:39:59
 //  Last edited:
-//    02 Nov 2023, 15:35:11
+//    08 Nov 2023, 13:56:27
 //  Auto updated?
 //    Yes
 //
@@ -20,7 +20,6 @@ use std::fmt::{Display, Formatter, Result as FResult};
 use std::panic::catch_unwind;
 
 use brane_ast::spec::BuiltinFunctions;
-use brane_ast::state::VirtualSymTable;
 use brane_ast::{ast, MergeStrategy};
 use enum_debug::EnumDebug as _;
 use log::trace;
@@ -106,7 +105,7 @@ impl error::Error for Error {
 ///
 /// # Arguments
 /// - `wir`: The [`ast::Workflow`] to analyse.
-/// - `table`: A running [`VirtualSymTable`] that determines the current types in scope.
+/// - `table`: A running [`ast::SymTable`] that determines the current types in scope.
 /// - `calls`: The map of Call program-counter-indices to function IDs called.
 /// - `pc`: The program-counter-index of the edge to analyse. These are pairs of `(function, edge_idx)`, where main is referred to by [`usize::MAX`](usize).
 /// - `plug`: The element to write when we reached the (implicit) end of a branch.
@@ -119,7 +118,7 @@ impl error::Error for Error {
 /// This function errors if a definition in the Workflow was unknown.
 fn reconstruct_graph(
     wir: &ast::Workflow,
-    table: &mut VirtualSymTable,
+    table: &ast::SymTable,
     calls: &HashMap<ProgramCounter, usize>,
     pc: ProgramCounter,
     plug: Elem,
@@ -326,11 +325,11 @@ impl TryFrom<ast::Workflow> for Workflow {
         };
 
         // Alright now attempt to re-build the graph in the new style
-        let graph: Elem =
-            reconstruct_graph(&wir, &mut VirtualSymTable::with(&wir.table), &calls, ProgramCounter::new(), Elem::Stop(HashSet::new()), None)?;
+        let graph: Elem = reconstruct_graph(&wir, &wir.table, &calls, ProgramCounter::new(), Elem::Stop(HashSet::new()), None)?;
 
         // Build a new Workflow with that!
         Ok(Self {
+            id:    String::new(),
             start: graph,
 
             user:      User { name: "Danny Data Scientist".into(), metadata: vec![] },

--- a/lib/workflow/src/eflint.rs
+++ b/lib/workflow/src/eflint.rs
@@ -1,0 +1,17 @@
+//  EFLINT.rs
+//    by Lut99
+//
+//  Created:
+//    08 Nov 2023, 14:44:31
+//  Last edited:
+//    08 Nov 2023, 14:44:42
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Defines a compiler of the Checker Workflow to the eFLINT JSON
+//!   Specification.
+//
+
+
+/***** LIBRARY *****/

--- a/lib/workflow/src/lib.rs
+++ b/lib/workflow/src/lib.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:54:17
 //  Last edited:
-//    01 Nov 2023, 10:07:52
+//    02 Nov 2023, 15:12:20
 //  Auto updated?
 //    Yes
 //
@@ -15,7 +15,9 @@
 // Declare the subsubmodules
 pub mod compile;
 pub mod optimize;
+pub mod preprocess;
 pub mod spec;
 #[cfg(test)]
 pub mod tests;
+pub mod utils;
 pub mod visualize;

--- a/lib/workflow/src/lib.rs
+++ b/lib/workflow/src/lib.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:54:17
 //  Last edited:
-//    08 Nov 2023, 10:18:46
+//    08 Nov 2023, 14:44:58
 //  Auto updated?
 //    Yes
 //
@@ -14,6 +14,8 @@
 
 // Declare the subsubmodules
 pub mod compile;
+#[cfg(feature = "eflint")]
+pub mod eflint;
 pub mod optimize;
 pub mod preprocess;
 pub mod spec;
@@ -21,9 +23,3 @@ pub mod spec;
 pub mod tests;
 pub mod utils;
 pub mod visualize;
-
-
-/***** CONSTANTS *****/
-/// Defines the location of the tests
-#[cfg(test)]
-const TESTS_DIR: &str = "../../tests";

--- a/lib/workflow/src/lib.rs
+++ b/lib/workflow/src/lib.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:54:17
 //  Last edited:
-//    07 Nov 2023, 10:22:46
+//    08 Nov 2023, 10:18:46
 //  Auto updated?
 //    Yes
 //
@@ -25,4 +25,5 @@ pub mod visualize;
 
 /***** CONSTANTS *****/
 /// Defines the location of the tests
+#[cfg(test)]
 const TESTS_DIR: &str = "../../tests";

--- a/lib/workflow/src/lib.rs
+++ b/lib/workflow/src/lib.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:54:17
 //  Last edited:
-//    02 Nov 2023, 15:12:20
+//    07 Nov 2023, 10:22:46
 //  Auto updated?
 //    Yes
 //
@@ -21,3 +21,8 @@ pub mod spec;
 pub mod tests;
 pub mod utils;
 pub mod visualize;
+
+
+/***** CONSTANTS *****/
+/// Defines the location of the tests
+const TESTS_DIR: &str = "../../tests";

--- a/lib/workflow/src/preprocess.rs
+++ b/lib/workflow/src/preprocess.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    02 Nov 2023, 14:52:26
 //  Last edited:
-//    08 Nov 2023, 14:38:25
+//    08 Nov 2023, 14:46:04
 //  Auto updated?
 //    Yes
 //
@@ -62,7 +62,7 @@ mod tests {
         ];
 
         // Load example package- and data indices
-        let tests_path: PathBuf = PathBuf::from(super::super::TESTS_DIR);
+        let tests_path: PathBuf = PathBuf::from(super::super::tests::TESTS_DIR);
         let pindex: PackageIndex = create_package_index_from(tests_path.join("packages"));
         let dindex: DataIndex = create_data_index_from(tests_path.join("data"));
 
@@ -112,7 +112,7 @@ mod tests {
     /// Runs the workflow inlining on the test files only
     #[test]
     fn test_checker_workflow_simplify() {
-        let tests_path: PathBuf = PathBuf::from(super::super::TESTS_DIR);
+        let tests_path: PathBuf = PathBuf::from(super::super::tests::TESTS_DIR);
 
         // Run the compiler for every applicable DSL file
         test_on_dsl_files_in("BraneScript", &tests_path, |path: PathBuf, code: String| {

--- a/lib/workflow/src/preprocess.rs
+++ b/lib/workflow/src/preprocess.rs
@@ -1,0 +1,361 @@
+//  PREPROCESS.rs
+//    by Lut99
+//
+//  Created:
+//    02 Nov 2023, 14:52:26
+//  Last edited:
+//    02 Nov 2023, 15:37:52
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Defines a preprocessing step on a [WIR](Workflow) that simplifies it
+//!   to increase the support of the simpler checker workflow.
+//
+
+use std::collections::{HashMap, HashSet};
+use std::error;
+use std::fmt::{Display, Formatter, Result as FResult};
+use std::panic::catch_unwind;
+
+use brane_ast::ast::{Edge, EdgeInstr, FunctionDef, TaskDef, Workflow};
+use brane_ast::state::VirtualSymTable;
+use brane_ast::MergeStrategy;
+use enum_debug::EnumDebug as _;
+use log::trace;
+
+use super::utils::{self, PrettyProgramCounter, ProgramCounter};
+
+
+/***** ERRORS *****/
+/// Defines errors that may occur when preprocessing a [`Workflow`].
+#[derive(Debug)]
+pub enum Error {
+    /// Unknown task given.
+    UnknownTask { id: usize },
+    /// Unknown function given.
+    UnknownFunc { id: usize },
+    /// A [`Call`](ast::Edge::Call)-edge was encountered while we didn't know of a function ID on the stack.
+    CallingWithoutId { pc: PrettyProgramCounter },
+}
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        use Error::*;
+        match self {
+            UnknownTask { id } => write!(f, "Encountered unknown task ID {id} in Node"),
+            UnknownFunc { id } => write!(f, "Encountered unknown function ID {id} in Call"),
+            CallingWithoutId { pc } => write!(f, "Attempted to call function at {pc} without statically known task ID on the stack"),
+        }
+    }
+}
+impl error::Error for Error {}
+
+
+
+
+
+/***** ANALYSIS FUNCTIONS *****/
+/// Checks whether the given stream of instructions would end with a function ID on top of the stack.
+///
+/// # Arguments
+/// - `instrs`: The list of instructions to analyse.
+/// - `idx`: The index of the particular instruction (i.e., the previous one) to examine. When calling this functio non-recursively, use the **last** instruction.
+///
+/// # Returns
+/// A double [`Option`] detailling what's possible:
+/// - [`Some(Some(...))`] means that there was a function ID on top.
+/// - [`Some(None)`] means that we _know_ there is _no_ function ID on top.
+/// - [`None`] means that nothing was pushed, i.e., whatever was on top is still on top.
+fn pushes_func_id(instrs: &[EdgeInstr], idx: usize) -> Option<Option<usize>> {
+    // Pop the next instruction
+    let instr: &EdgeInstr = if idx < instrs.len() {
+        &instrs[idx]
+    } else {
+        // If we reached the last instruction, then we know no value was pushed :celebrate:
+        return None;
+    };
+
+    // Examine what it does
+    // NOTE: The BraneScript compiler only supports function calls over identifiers and projections. So we can ignore gnarly array stuff etc!
+    // NOTE: Actually... we know violently little statically of class calls in general, because they are fully pushed to dynamic land. We _could_ learn it by tracking
+    //       a variable's contents over multiple edges, but that fucks; let's give up and only support direct calls for now.
+    match instr {
+        // What we're looking for!
+        EdgeInstr::Function { def } => Some(Some(*def)),
+
+        // Things instructions only pop, potentially (accidentally) removing our function
+        // Jep just tell the thign we don't know, we don't need it for direct function calls
+        EdgeInstr::Pop {} | EdgeInstr::PopMarker {} | EdgeInstr::DynamicPop {} | EdgeInstr::VarSet { .. } => Some(None),
+
+        // Alright some weird local branching; fuck it, also give up because we don't know which of the branches will do it
+        EdgeInstr::Branch { .. } | EdgeInstr::BranchNot { .. } => Some(None),
+
+        // These instructions never pop- or push anything
+        EdgeInstr::VarDec { .. } | EdgeInstr::VarUndec { .. } => Some(None),
+
+        // These instructions push invalid things _for sure_
+        EdgeInstr::Cast { .. }
+        | EdgeInstr::Not {}
+        | EdgeInstr::Neg {}
+        | EdgeInstr::And {}
+        | EdgeInstr::Or {}
+        | EdgeInstr::Add {}
+        | EdgeInstr::Sub {}
+        | EdgeInstr::Mul {}
+        | EdgeInstr::Div {}
+        | EdgeInstr::Mod {}
+        | EdgeInstr::Eq {}
+        | EdgeInstr::Ne {}
+        | EdgeInstr::Lt {}
+        | EdgeInstr::Le {}
+        | EdgeInstr::Gt {}
+        | EdgeInstr::Ge {}
+        | EdgeInstr::Array { .. }
+        | EdgeInstr::ArrayIndex { .. }
+        | EdgeInstr::Instance { .. }
+        | EdgeInstr::Proj { .. }
+        | EdgeInstr::VarGet { .. }
+        | EdgeInstr::Boolean { .. }
+        | EdgeInstr::Integer { .. }
+        | EdgeInstr::Real { .. }
+        | EdgeInstr::String { .. } => Some(None),
+    }
+}
+
+/// Analyses the edges in an [`Workflow`] to resolve function calls to the ID of the functions they call.
+///
+/// # Arguments
+/// - `wir`: The [`Workflow`] to analyse.
+/// - `table`: A running [`VirtualSymTable`] that determines the current types in scope.
+/// - `stack_id`: The function ID currently known to be on the stack. Is [`None`] if we don't know this.
+/// - `pc`: The program-counter-index of the edge to analyse. These are pairs of `(function, edge_idx)`, where main is referred to by [`usize::MAX`](usize).
+/// - `breakpoint`: An optional program-counter-index that, if given, will not analyse that edge onwards (excluding it too).
+///
+/// # Returns
+/// A tuple with a [`HashMap`] that maps call indices (as program-counter-indices) to function IDs and an optional top call ID currently on the stack.
+///
+/// Note that, if a call ID occurs in the map but has [`None`] as function ID, it means it does not map to a body (e.g., a builtin).
+///
+/// # Errors
+/// This function may error if we failed to statically discover the function IDs.
+fn resolve_calls(
+    wir: &Workflow,
+    table: &mut VirtualSymTable,
+    pc: ProgramCounter,
+    stack_id: Option<usize>,
+    breakpoint: Option<ProgramCounter>,
+) -> Result<(HashMap<ProgramCounter, usize>, Option<usize>), Error> {
+    // Quit if we're at the breakpoint
+    if let Some(breakpoint) = breakpoint {
+        if pc == breakpoint {
+            return Ok((HashMap::new(), None));
+        }
+    }
+
+    // Get the edge in the workflow
+    let edge: &Edge = match utils::get_edge(wir, pc) {
+        Some(edge) => edge,
+        None => return Ok((HashMap::new(), None)),
+    };
+
+    // Match to recursively process it
+    trace!("Analyzing {:?} calls", edge.variant());
+    match edge {
+        Edge::Node { task, next, .. } => {
+            // Attempt to discover the return type of the Node.
+            let def: &TaskDef = match std::panic::catch_unwind(|| table.task(*task)) {
+                Ok(def) => def,
+                Err(_) => return Err(Error::UnknownTask { id: *task }),
+            };
+
+            // Alright, recurse with the next instruction
+            resolve_calls(wir, table, pc.jump(*next), if def.func().ret.is_void() { stack_id } else { None }, breakpoint)
+        },
+
+        Edge::Linear { instrs, next } => {
+            // Analyse the instructions to find out if we can deduce a new `stack_id`
+            let stack_id: Option<usize> = if !instrs.is_empty() { pushes_func_id(instrs, instrs.len() - 1).unwrap_or(stack_id) } else { stack_id };
+
+            // Analyse the next one
+            resolve_calls(wir, table, pc.jump(*next), stack_id, breakpoint)
+        },
+
+        Edge::Stop {} => Ok((HashMap::new(), None)),
+
+        Edge::Branch { true_next, false_next, merge } => {
+            // First, analyse the branches
+            let (mut calls, mut stack_id): (HashMap<_, _>, Option<usize>) =
+                resolve_calls(wir, table, pc.jump(*true_next), stack_id, merge.map(|merge| pc.jump(merge)))?;
+            if let Some(false_next) = false_next {
+                let (false_calls, false_stack) = resolve_calls(wir, table, pc.jump(*false_next), stack_id, merge.map(|merge| pc.jump(merge)))?;
+                calls.extend(false_calls);
+                if stack_id != false_stack {
+                    stack_id = None;
+                }
+            }
+
+            // Analyse the remaining part next
+            if let Some(merge) = merge {
+                let (merge_calls, merge_stack) = resolve_calls(wir, table, pc.jump(*merge), stack_id, breakpoint)?;
+                calls.extend(merge_calls);
+                stack_id = merge_stack;
+            }
+
+            // Alright, return the found results
+            Ok((calls, stack_id))
+        },
+
+        Edge::Parallel { branches, merge } => {
+            // Simply analyse all branches first. No need to worry about their return values and such, since that's not until the `Join`.
+            let mut calls: HashMap<_, _> = HashMap::new();
+            for branch in branches {
+                calls.extend(resolve_calls(wir, table, pc.jump(*branch), stack_id, breakpoint)?.0);
+            }
+
+            // OK, then analyse the rest assuming the stack is unchanged (we can do that because the parallel's branches get clones)
+            let (new_calls, stack_id): (HashMap<_, _>, Option<usize>) = resolve_calls(wir, table, pc.jump(*merge), stack_id, breakpoint)?;
+            calls.extend(new_calls);
+            Ok((calls, stack_id))
+        },
+
+        Edge::Join { merge, next } => {
+            // Simply do the next, only _not_ resetting the stack ID if no value is returned.
+            resolve_calls(wir, table, pc.jump(*next), if *merge == MergeStrategy::None { stack_id } else { None }, breakpoint)
+        },
+
+        Edge::Loop { cond, body, next } => {
+            // Traverse the three individually, using the stack ID of the codebody that precedes it
+            let (mut calls, mut cond_id): (HashMap<_, _>, Option<usize>) =
+                resolve_calls(wir, table, pc.jump(*cond), stack_id, Some(pc.jump(*body - 1)))?;
+            let (body_calls, _): (HashMap<_, _>, Option<usize>) = resolve_calls(wir, table, pc.jump(*body), cond_id, Some(pc.jump(*cond)))?;
+            calls.extend(body_calls);
+            if let Some(next) = next {
+                let (next_calls, next_id): (HashMap<_, _>, Option<usize>) = resolve_calls(wir, table, pc.jump(*next), cond_id, breakpoint)?;
+                calls.extend(next_calls);
+                cond_id = next_id;
+            }
+
+            // Done!
+            Ok((calls, cond_id))
+        },
+
+        Edge::Call { input: _, result: _, next } => {
+            // Alright time to jump functions based on the current top-of-the-stack
+            let stack_id: usize = match stack_id {
+                Some(id) => id,
+                None => {
+                    return Err(Error::CallingWithoutId { pc: pc.display(table) });
+                },
+            };
+
+            // Get the function definition to extend the VirtualSymTable
+            let def: &FunctionDef = match catch_unwind(|| table.func(stack_id)) {
+                Ok(def) => def,
+                Err(_) => return Err(Error::UnknownFunc { id: stack_id }),
+            };
+
+            // Add the mapping to the table
+            let mut calls: HashMap<ProgramCounter, usize> = HashMap::from([(pc, stack_id)]);
+
+            // Resolve the call of the function (builtins simply return nothing, so are implicitly handled)
+            table.push(&def.table);
+            let (call_calls, call_id): (HashMap<_, _>, Option<usize>) = resolve_calls(wir, table, ProgramCounter::call(stack_id), None, None)?;
+            table.pop();
+            calls.extend(call_calls);
+
+            // Then continue with the next one
+            let (next_calls, next_id): (HashMap<_, _>, Option<usize>) = resolve_calls(wir, table, pc.jump(*next), call_id, breakpoint)?;
+            calls.extend(next_calls);
+            Ok((calls, next_id))
+        },
+
+        Edge::Return { result: _ } => {
+            // If we're in the main function, this acts as an [`Elem::Stop`] with value
+            if pc.0 == usize::MAX {
+                return Ok((HashMap::new(), None));
+            }
+
+            // To see whether we pass a function ID, consult the function definition
+            let def: &FunctionDef = match catch_unwind(|| table.func(pc.0)) {
+                Ok(def) => def,
+                Err(_) => return Err(Error::UnknownFunc { id: pc.0 }),
+            };
+
+            // Only return the current one if the function returns void
+            if def.ret.is_void() { Ok((HashMap::new(), stack_id)) } else { Ok((HashMap::new(), None)) }
+        },
+    }
+}
+
+/// Attempts to find all non-recursive functions in the given WIR.
+///
+/// The only moment when we don't consider a function inlinable is if the function call is:
+/// - Recursive
+/// - A builtin
+/// - Undecidable
+///
+/// # Arguments
+/// - `wir`: The input [WIR](Workflow) to analyse.
+///
+/// # Returns
+/// A [`HashSet`] with all the IDs of the functions that are candidates for inlining.
+fn find_non_recursive_funcs(wir: &Workflow, calls: &HashMap<ProgramCounter, usize>) -> HashSet<usize> { HashSet::new() }
+
+
+
+
+
+/***** SIMPLIFICATION FUNCTIONS *****/
+/// Attempts to inline functions in the WIR as much as possible.
+///
+/// The only moment when we don't is if the function call is:
+/// - Recursive
+/// - A builtin
+/// - Undecidable
+///
+/// # Arguments
+/// - `wir`: The input [WIR](Workflow) to simply.
+/// - `calls`: The map of call indices to which function is actually called.
+///
+/// # Returns
+/// The same `wir` as given, but then optimized.
+///
+/// # Errors
+/// This function may error if the input workflow is incoherent.
+pub fn inline_functions(mut wir: Workflow, calls: &HashMap<ProgramCounter, usize>) -> Workflow {
+    // Analyse which functions in the WIR are non-recursive
+    let to_inline: HashSet<usize> = find_non_recursive_funcs(&wir, calls);
+
+    // OK, we did all we could
+    wir
+}
+
+
+
+
+
+/***** LIBRARY *****/
+/// Simplifies the given WIR-workflow as much as possible to increase the compatability with checker workflows.
+///
+/// Most importantly, it:
+/// - Attempts to inline functions as long as they're non-recursive (since functions are not supported)
+///
+/// # Arguments
+/// - `wir`: The input [WIR](Workflow) to simply.
+///
+/// # Returns
+/// A tuple of the same `wir` as given, but then optimized, and a mapping of (remaining) [`Edge::Call`]s to whatever function they actually map.
+///
+/// # Errors
+/// This function may error if the input workflow is incoherent.
+pub fn simplify(mut wir: Workflow) -> Result<(Workflow, HashMap<ProgramCounter, usize>), Error> {
+    // Analyse call dependencies first
+    let (calls, _): (HashMap<ProgramCounter, usize>, _) =
+        resolve_calls(&wir, &mut VirtualSymTable::with(&wir.table), ProgramCounter::new(), None, None)?;
+
+    // Simplify functions as much as possible
+    wir = inline_functions(wir, &calls);
+
+    // Done!
+    Ok((wir, calls))
+}

--- a/lib/workflow/src/spec.rs
+++ b/lib/workflow/src/spec.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:56:55
 //  Last edited:
-//    02 Nov 2023, 14:40:06
+//    08 Nov 2023, 13:21:30
 //  Auto updated?
 //    Yes
 //
@@ -266,6 +266,18 @@ pub struct Dataset {
     /// Any metadata attached to the dataset. Note: may need to be populated by the checker!
     pub metadata: Vec<Metadata>,
 }
+impl Dataset {
+    /// Constructor for the Dataset that only takes information originating from the workflow.
+    ///
+    /// # Arguments
+    /// - `name`: The name of the dataset.
+    /// - `from`: The location where to pull the dataset from, or [`None`] if no transfer is planned (i.e., it lives on the same domain as the task using it as input).
+    ///
+    /// # Returns
+    /// A new instance of self with the given `name` and `from`, and all other properties initialized to some default value.
+    #[inline]
+    pub fn new(name: impl Into<String>, from: impl Into<Option<Location>>) -> Self { Self { name: name.into(), from: from.into(), metadata: vec![] } }
+}
 impl Eq for Dataset {}
 impl PartialEq for Dataset {
     #[inline]
@@ -279,11 +291,13 @@ impl Hash for Dataset {
 /// Represents a "tag" and everything we need to know.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Metadata {
+    /// The "namespace" where the tag may be found. Represents the "owner", or the "definer" of the tag.
+    pub owner: String,
     /// The tag itself.
     pub tag: String,
-    /// The namespace where the tag may be found. Represents the "owner", or the "definer" of the tag.
-    pub namespace: String,
-    /// The signature verifying this metadata. Represents the "assigner", or the "user" of the tag.
+    /// The person/domain who applied this tag to something and then signed the assignment.
+    pub assigner: String,
+    /// The signature verifying this metadata. It can be assumed that this is signed by the `assigner`.
     pub signature: String,
     /// A flag stating whether the signature is valid. If [`None`], means this hasn't been validated yet.
     pub signature_valid: Option<bool>,
@@ -297,6 +311,8 @@ pub struct Metadata {
 /// Defines the workflow's toplevel view.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
+    /// The identifier of this workflow as a whole.
+    pub id:    String,
     /// Defines the first node in the workflow.
     pub start: Elem,
 

--- a/lib/workflow/src/spec.rs
+++ b/lib/workflow/src/spec.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:56:55
 //  Last edited:
-//    31 Oct 2023, 15:39:22
+//    02 Nov 2023, 14:40:06
 //  Auto updated?
 //    Yes
 //
@@ -12,13 +12,13 @@
 //!   Defines the checker workflow itself.
 //
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::collections::HashSet;
+use std::hash::Hash;
 
 use brane_ast::locations::Location;
 use brane_ast::MergeStrategy;
 use enum_debug::EnumDebug;
+use serde::{Deserialize, Serialize};
 use specifications::version::Version;
 
 
@@ -52,7 +52,7 @@ macro_rules! next_elem_checks_impl {
         pub fn is_some(&self) -> bool { self.is_elem() }
         #[doc = concat!("Checks if a terminator has been reached or not.\n\n# Returns\nTrue if we are [Self::Next](", stringify!($name), "::Next) or [Self::Stop](", stringify!($name), "::Stop), or false otherwise.")]
         #[inline]
-        pub fn is_term(&self) -> bool { self.is_next() || self.is_return() || self.is_stop() }
+        pub fn is_term(&self) -> bool { self.is_next() || self.is_stop() }
 
         #[doc = concat!("Checks if there is a next node or not.\n\n# Returns\nTrue if we are [Self::Elem](", stringify!($name), "::Elem), or false otherwise.")]
         #[inline]
@@ -60,12 +60,9 @@ macro_rules! next_elem_checks_impl {
         #[doc = concat!("Checks if a `Next`-terminator has been reached.\n\n# Returns\nTrue if we are [Self::Next](", stringify!($name), "::Next), or false otherwise.")]
         #[inline]
         pub fn is_next(&self) -> bool { matches!(self, Self::Next) }
-        #[doc = concat!("Checks if a `Return`-terminator has been reached.\n\n# Returns\nTrue if we are [Self::Return](", stringify!($name), "::Return), or false otherwise.")]
-        #[inline]
-        pub fn is_return(&self) -> bool { matches!(self, Self::Return) }
         #[doc = concat!("Checks if a `Stop`-terminator has been reached.\n\n# Returns\nTrue if we are [Self::Stop](", stringify!($name), "::Stop), or false otherwise.")]
         #[inline]
-        pub fn is_stop(&self) -> bool { matches!(self, Self::Stop) }
+        pub fn is_stop(&self) -> bool { matches!(self, Self::Stop(_)) }
     };
 }
 
@@ -105,14 +102,17 @@ macro_rules! next_elem_ref_impl {
         #[inline]
         pub fn elem(&self) -> &Elem { if let Self::Elem(e) = self { e } else { panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Elem"), self.variant()); } }
 
+        #[doc = concat!("Returns the inner next value if this is a terminator.\n\n# Returns\nA reference to the [`Option<Dataset>`] that is contained within.\n\n# Panics\nThis function panics if we are not a [`Self::Stop](", stringify!($name), "::Stop).")]
+        #[inline]
+        pub fn returns(&self) -> &HashSet<Dataset> { match self { Self::Stop(r) => r, this => panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Stop"), this.variant()), } }
+
         #[doc = concat!("Return a [`NextElemRef`] from this ", stringify!($name), ".\n\n# Returns\nA [`NextElemRef`] that contains a reference to the element in Self, if any.")]
         #[inline]
         pub fn as_ref(&self) -> NextElemRef {
             match self {
                 Self::Elem(e) => NextElemRef::Elem(e),
                 Self::Next    => NextElemRef::Next,
-                Self::Return  => NextElemRef::Return,
-                Self::Stop    => NextElemRef::Stop,
+                Self::Stop(r) => NextElemRef::Stop(r),
             }
         }
     };
@@ -154,14 +154,17 @@ macro_rules! next_elem_mut_impl {
         #[inline]
         pub fn elem_mut(&mut self) -> &mut Elem { if let Self::Elem(e) = self { e } else { panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Elem"), self.variant()); } }
 
+        #[doc = concat!("Returns the inner next value if this is a terminator.\n\n# Returns\nA mutable reference to the [`Option<Dataset>`] that is contained within.\n\n# Panics\nThis function panics if we are not a [`Self::Stop](", stringify!($name), "::Stop).")]
+        #[inline]
+        pub fn returns_mut(&mut self) -> &mut HashSet<Dataset> { match self { Self::Stop(r) => r, this => panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Stop"), this.variant()), } }
+
         #[doc = concat!("Return a [`NextElemMut`] from this ", stringify!($name), ".\n\n# Returns\nA [`NextElemMut`] that contains a mutable reference to the element in Self, if any.")]
         #[inline]
         pub fn as_mut(&mut self) -> NextElemMut {
             match self {
                 Self::Elem(e) => NextElemMut::Elem(e),
                 Self::Next    => NextElemMut::Next,
-                Self::Return  => NextElemMut::Return,
-                Self::Stop    => NextElemMut::Stop,
+                Self::Stop(r) => NextElemMut::Stop(r),
             }
         }
     };
@@ -178,6 +181,10 @@ macro_rules! next_elem_into_impl {
             #[doc = concat!("Returns the inner next graph element.\n\n# Returns\nThe [`Elem`] that is contained within.\n\n#Panics\nThis function panics if we are not a [`Self::Elem`](", stringify!($name), "::Elem).")]
             #[inline]
             pub fn into_elem(self) -> Elem { if let Self::Elem(e) = self { e } else { panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Elem"), self.variant()); } }
+
+            #[doc = concat!("Returns the inner next value if this is a terminator.\n\n# Returns\nThe [`Option<Dataset>`] that is contained within.\n\n# Panics\nThis function panics if we are not a [`Self::Stop](", stringify!($name), "::Stop).")]
+            #[inline]
+            pub fn into_returns(self) -> HashSet<Dataset> { match self { Self::Stop(r) => r, this => panic!(concat!("Cannot unwrap {:?} as a ", stringify!($name), "::Stop"), this.variant()), } }
         }
     };
 }
@@ -196,10 +203,8 @@ pub enum NextElem {
     Elem(Elem),
     /// An [`Elem::Next`]-terminator was encountered.
     Next,
-    /// An [`Elem::Return`]-terminator was encountered.
-    Return,
     /// An [`Elem::Stop`]-terminator was encountered.
-    Stop,
+    Stop(HashSet<Dataset>),
 }
 next_elem_checks_impl!(NextElem);
 next_elem_ref_impl!(NextElem);
@@ -215,10 +220,8 @@ pub enum NextElemRef<'e> {
     Elem(&'e Elem),
     /// An [`Elem::Next`]-terminator was encountered.
     Next,
-    /// An [`Elem::Return`]-terminator was encountered.
-    Return,
     /// An [`Elem::Stop`]-terminator was encountered.
-    Stop,
+    Stop(&'e HashSet<Dataset>),
 }
 next_elem_checks_impl!('e, NextElemRef);
 next_elem_ref_impl!('e, NextElemRef);
@@ -232,10 +235,8 @@ pub enum NextElemMut<'e> {
     Elem(&'e mut Elem),
     /// An [`Elem::Next`]-terminator was encountered.
     Next,
-    /// An [`Elem::Return`]-terminator was encountered.
-    Return,
     /// An [`Elem::Stop`]-terminator was encountered.
-    Stop,
+    Stop(&'e mut HashSet<Dataset>),
 }
 next_elem_checks_impl!('e, NextElemMut);
 next_elem_ref_impl!('e, NextElemMut);
@@ -247,7 +248,7 @@ next_elem_mut_impl!('e, NextElemMut);
 
 /***** AUXILLARY DATA *****/
 /// Defines how a user looks like.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
     /// The name of the user.
     pub name:     String,
@@ -255,15 +256,8 @@ pub struct User {
     pub metadata: Vec<Metadata>,
 }
 
-/// Defines the metadata of a particular **function** (not task).
-#[derive(Clone, Debug)]
-pub struct Function {
-    /// The name of the function.
-    pub name: String,
-}
-
 /// Defines a representation of a dataset.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Dataset {
     /// The name of the dataset.
     pub name:     String,
@@ -272,9 +266,18 @@ pub struct Dataset {
     /// Any metadata attached to the dataset. Note: may need to be populated by the checker!
     pub metadata: Vec<Metadata>,
 }
+impl Eq for Dataset {}
+impl PartialEq for Dataset {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool { self.name == other.name }
+}
+impl Hash for Dataset {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) { self.name.hash(state) }
+}
 
 /// Represents a "tag" and everything we need to know.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Metadata {
     /// The tag itself.
     pub tag: String,
@@ -292,12 +295,10 @@ pub struct Metadata {
 
 /***** LIBRARY *****/
 /// Defines the workflow's toplevel view.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
     /// Defines the first node in the workflow.
     pub start: Elem,
-    /// The functions part of this workflow. These are [`Rc`]-pointers, as they occur naturally within the workflow as well.
-    pub funcs: HashMap<usize, (Function, FunctionBody)>,
 
     /// The user instigating this workflow (and getting the result, if any).
     pub user:      User,
@@ -310,11 +311,13 @@ pub struct Workflow {
 
 
 /// Defines an element in the graph. This is either a _Node_, which defines a task execution, or an _Edge_, which defines how next tasks may be reached.
-#[derive(Clone, Debug, EnumDebug)]
+#[derive(Clone, Debug, Deserialize, EnumDebug, Serialize)]
 pub enum Elem {
     // Nodes
-    /// Defines a task, which is like a [linear edge](Elem::Linear) but with a task to execute.
+    /// Defines a task that is executed, accessing and potentially producing data.
     Task(ElemTask),
+    /// Defines the commiting of a result into a dataset, which will linger beyong the workflow with a specific name.
+    Commit(ElemCommit),
 
     // Edges
     /// Defines an edge that connects to multiple next graph-branches of which only _one_ must be taken. Note that, because we don't include dynamic control flow information, we don't know _which_ will be taken.
@@ -323,20 +326,14 @@ pub enum Elem {
     Parallel(ElemParallel),
     /// Defines an edge that repeats a particular branch an unknown amount of times.
     Loop(ElemLoop),
-    /// Calls another stream of edges, then continues onwards.
-    Call(ElemCall),
 
     // Terminators
     /// Defines that the next element to execute is given by the parent `next`-field.
-    ///
-    /// If occuring in a function, it means a return without value.
     Next,
-    /// Defines that the next element to execute is given by the parent `next`-field, but with some value.
-    ///
-    /// If occuring in the main, it means a value is returned from the workflow.
-    Return,
     /// Defines that no more execution takes place.
-    Stop,
+    ///
+    /// The option indicates if any data is carried to the remaining code.
+    Stop(HashSet<Dataset>),
 }
 impl Elem {
     /// Retrieves the `next` element of ourselves.
@@ -348,15 +345,14 @@ impl Elem {
     pub fn next(&self) -> NextElemRef {
         match self {
             Self::Task(ElemTask { next, .. }) => NextElemRef::Elem(next),
+            Self::Commit(ElemCommit { next, .. }) => NextElemRef::Elem(next),
 
-            Self::Branch(ElemBranch { next, .. })
-            | Self::Parallel(ElemParallel { next, .. })
-            | Self::Loop(ElemLoop { next, .. })
-            | Self::Call(ElemCall { next, .. }) => NextElemRef::Elem(next),
+            Self::Branch(ElemBranch { next, .. }) | Self::Parallel(ElemParallel { next, .. }) | Self::Loop(ElemLoop { next, .. }) => {
+                NextElemRef::Elem(next)
+            },
 
             Self::Next => NextElemRef::Next,
-            Self::Return => NextElemRef::Return,
-            Self::Stop => NextElemRef::Stop,
+            Self::Stop(returns) => NextElemRef::Stop(returns),
         }
     }
 
@@ -369,15 +365,14 @@ impl Elem {
     pub fn next_mut(&mut self) -> NextElemMut {
         match self {
             Self::Task(ElemTask { next, .. }) => NextElemMut::Elem(next),
+            Self::Commit(ElemCommit { next, .. }) => NextElemMut::Elem(next),
 
-            Self::Branch(ElemBranch { next, .. })
-            | Self::Parallel(ElemParallel { next, .. })
-            | Self::Loop(ElemLoop { next, .. })
-            | Self::Call(ElemCall { next, .. }) => NextElemMut::Elem(next),
+            Self::Branch(ElemBranch { next, .. }) | Self::Parallel(ElemParallel { next, .. }) | Self::Loop(ElemLoop { next, .. }) => {
+                NextElemMut::Elem(next)
+            },
 
             Self::Next => NextElemMut::Next,
-            Self::Return => NextElemMut::Return,
-            Self::Stop => NextElemMut::Stop,
+            Self::Stop(returns) => NextElemMut::Stop(returns),
         }
     }
 
@@ -390,23 +385,22 @@ impl Elem {
     pub fn into_next(self) -> NextElem {
         match self {
             Self::Task(ElemTask { next, .. }) => NextElem::Elem(*next),
+            Self::Commit(ElemCommit { next, .. }) => NextElem::Elem(*next),
 
-            Self::Branch(ElemBranch { next, .. })
-            | Self::Parallel(ElemParallel { next, .. })
-            | Self::Loop(ElemLoop { next, .. })
-            | Self::Call(ElemCall { next, .. }) => NextElem::Elem(*next),
+            Self::Branch(ElemBranch { next, .. }) | Self::Parallel(ElemParallel { next, .. }) | Self::Loop(ElemLoop { next, .. }) => {
+                NextElem::Elem(*next)
+            },
 
             Self::Next => NextElem::Next,
-            Self::Return => NextElem::Return,
-            Self::Stop => NextElem::Stop,
+            Self::Stop(returns) => NextElem::Stop(returns),
         }
     }
 }
 
-/// Defines the only node in the graph consisting of [`Elem`]s.
+/// Defines a task node in the graph consisting of [`Elem`]s, which defines data access.
 ///
 /// Yeah so basically represents a task execution, with all checker-relevant information.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElemTask {
     /// The name of the task to execute
     pub name:    String,
@@ -418,6 +412,8 @@ pub struct ElemTask {
     pub hash:    Option<String>,
 
     /// Any input datasets used by the task.
+    ///
+    /// Note that this denotes a set of **possible** input sets. One or more of these may actually be used at runtime.
     pub input:  Vec<Dataset>,
     /// If there is an output dataset produced by this task, this names it.
     pub output: Option<Dataset>,
@@ -433,10 +429,26 @@ pub struct ElemTask {
     pub next: Box<Elem>,
 }
 
+/// Defines a commit node in the graph consisting of [`Elem`]s, which defines data promotion.
+///
+/// Checkers can assume that anything produced by a function will be deleted after the workflow stops (or at least, domains **should** do so) _unless_ committed.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ElemCommit {
+    /// The name after committing.
+    pub data_name: String,
+    /// Any input datasets used by the task.
+    ///
+    /// Note that this denotes a set of **possible** input sets. One or more of these may actually be used at runtime.
+    pub input:     Vec<Dataset>,
+
+    /// The next graph element that this task connects to.
+    pub next: Box<Elem>,
+}
+
 /// Defines a branching connection between graph [`Elem`]ents.
 ///
 /// Or rather, defines a linear connection between two nodes, with a set of branches in between them.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElemBranch {
     /// The branches of which one _must_ be taken, but we don't know which one.
     pub branches: Vec<Elem>,
@@ -447,7 +459,7 @@ pub struct ElemBranch {
 /// Defines a parallel connection between graph [`Elem`]ents.
 ///
 /// Is like a [branch](ElemBranch), except that _all_ branches are taken _concurrently_ instead of only one.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElemParallel {
     /// The branches, _all_ of which but be taken _concurrently_.
     pub branches: Vec<Elem>,
@@ -460,31 +472,10 @@ pub struct ElemParallel {
 /// Defines a looping connection between graph [`Elem`]ents.
 ///
 /// Simply defines a branch that is taken repeatedly. Any condition that was there is embedded in the branching part, since that's how the branch is dynamically taken and we can't know how often any of them is taken anyway.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElemLoop {
     /// The body (and embedded condition) of the loop.
     pub body: Box<Elem>,
     /// The next graph element that this parallel edge connects to.
     pub next: Box<Elem>,
-}
-
-/// Defines a calling connection between graph [`Elem`]ents.
-///
-/// Refers (not defines) to a shared-ownership branch of elements that is executed before the `next`` element is continued with.
-#[derive(Clone, Debug)]
-pub struct ElemCall {
-    /// The ID of the function we're calling.
-    pub id:   usize,
-    /// The set of elements to call. Note that this may represent a concrete body of elements _or_ some reference to a builtin.
-    pub func: FunctionBody,
-    /// The next graph element that this calling edge connects to.
-    pub next: Box<Elem>,
-}
-/// The possibilities that make up a function body.
-#[derive(Clone, Debug, EnumDebug)]
-pub enum FunctionBody {
-    /// It's a concrete tree of elements.
-    Elems(Rc<RefCell<Elem>>),
-    /// It's a builtin with a given name.
-    Builtin,
 }

--- a/lib/workflow/src/spec.rs
+++ b/lib/workflow/src/spec.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    27 Oct 2023, 15:56:55
 //  Last edited:
-//    08 Nov 2023, 13:21:30
+//    08 Nov 2023, 14:11:06
 //  Auto updated?
 //    Yes
 //
@@ -418,6 +418,9 @@ impl Elem {
 /// Yeah so basically represents a task execution, with all checker-relevant information.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElemTask {
+    /// Some identifier for this _task_, i.e., the call.
+    pub id: String,
+
     /// The name of the task to execute
     pub name:    String,
     /// The name of the package in which to find the task.

--- a/lib/workflow/src/tests.rs
+++ b/lib/workflow/src/tests.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    31 Oct 2023, 15:27:38
 //  Last edited:
-//    08 Nov 2023, 14:35:37
+//    08 Nov 2023, 14:45:36
 //  Auto updated?
 //    Yes
 //
@@ -25,11 +25,19 @@ use specifications::package::PackageIndex;
 use super::spec::Workflow;
 
 
+/***** CONSTANTS *****/
+/// Defines the location of the tests
+pub(crate) const TESTS_DIR: &str = "../../tests";
+
+
+
+
+
 /***** LIBRARY *****/
 /// Run all the BraneScript tests
 #[test]
 fn test_checker_workflow_unoptimized() {
-    let tests_path: PathBuf = PathBuf::from(super::TESTS_DIR);
+    let tests_path: PathBuf = PathBuf::from(TESTS_DIR);
 
     // Run the compiler for every applicable DSL file
     test_on_dsl_files_in("BraneScript", &tests_path, |path: PathBuf, code: String| {
@@ -102,7 +110,7 @@ fn test_checker_workflow_unoptimized() {
 /// Run all the BraneScript tests _with_ optimization
 #[test]
 fn test_checker_workflow_optimized() {
-    let tests_path: PathBuf = PathBuf::from(super::TESTS_DIR);
+    let tests_path: PathBuf = PathBuf::from(TESTS_DIR);
 
     // Run the compiler for every applicable DSL file
     test_on_dsl_files_in("BraneScript", &tests_path, |path: PathBuf, code: String| {

--- a/lib/workflow/src/tests.rs
+++ b/lib/workflow/src/tests.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    31 Oct 2023, 15:27:38
 //  Last edited:
-//    07 Nov 2023, 10:23:00
+//    08 Nov 2023, 14:35:37
 //  Auto updated?
 //    Yes
 //
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 use brane_ast::{ast, compile_program, CompileResult, ParserOptions};
 use brane_shr::utilities::{create_data_index_from, create_package_index_from, test_on_dsl_files_in};
+use log::{debug, Level};
 use specifications::data::DataIndex;
 use specifications::package::PackageIndex;
 
@@ -27,7 +28,7 @@ use super::spec::Workflow;
 /***** LIBRARY *****/
 /// Run all the BraneScript tests
 #[test]
-fn test_checker_workflow() {
+fn test_checker_workflow_unoptimized() {
     let tests_path: PathBuf = PathBuf::from(super::TESTS_DIR);
 
     // Run the compiler for every applicable DSL file
@@ -75,6 +76,14 @@ fn test_checker_workflow() {
                 unreachable!();
             },
         };
+
+        // Print the WIR in debug mode
+        if log::max_level() >= Level::Debug {
+            // Write the processed graph
+            let mut buf: Vec<u8> = vec![];
+            brane_ast::traversals::print::ast::do_traversal(&wir, &mut buf).unwrap();
+            debug!("Compiled workflow:\n\n{}\n", String::from_utf8_lossy(&buf));
+        }
 
         // Next, compile to the checker's workflow
         let wf: Workflow = match wir.try_into() {
@@ -140,6 +149,14 @@ fn test_checker_workflow_optimized() {
                 unreachable!();
             },
         };
+
+        // Print the WIR in debug mode
+        if log::max_level() >= Level::Debug {
+            // Write the processed graph
+            let mut buf: Vec<u8> = vec![];
+            brane_ast::traversals::print::ast::do_traversal(&wir, &mut buf).unwrap();
+            debug!("Compiled workflow:\n\n{}\n", String::from_utf8_lossy(&buf));
+        }
 
         // Next, compile to the checker's workflow
         let mut wf: Workflow = match wir.try_into() {

--- a/lib/workflow/src/tests.rs
+++ b/lib/workflow/src/tests.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    31 Oct 2023, 15:27:38
 //  Last edited:
-//    01 Nov 2023, 14:10:56
+//    07 Nov 2023, 10:23:00
 //  Auto updated?
 //    Yes
 //
@@ -24,19 +24,11 @@ use specifications::package::PackageIndex;
 use super::spec::Workflow;
 
 
-/***** CONSTANTS *****/
-/// Defines the location of the tests
-pub const TESTS_DIR: &str = "../../tests";
-
-
-
-
-
 /***** LIBRARY *****/
 /// Run all the BraneScript tests
 #[test]
 fn test_checker_workflow() {
-    let tests_path: PathBuf = PathBuf::from(TESTS_DIR);
+    let tests_path: PathBuf = PathBuf::from(super::TESTS_DIR);
 
     // Run the compiler for every applicable DSL file
     test_on_dsl_files_in("BraneScript", &tests_path, |path: PathBuf, code: String| {
@@ -101,7 +93,7 @@ fn test_checker_workflow() {
 /// Run all the BraneScript tests _with_ optimization
 #[test]
 fn test_checker_workflow_optimized() {
-    let tests_path: PathBuf = PathBuf::from(TESTS_DIR);
+    let tests_path: PathBuf = PathBuf::from(super::TESTS_DIR);
 
     // Run the compiler for every applicable DSL file
     test_on_dsl_files_in("BraneScript", &tests_path, |path: PathBuf, code: String| {

--- a/lib/workflow/src/utils.rs
+++ b/lib/workflow/src/utils.rs
@@ -1,0 +1,134 @@
+//  UTILS.rs
+//    by Lut99
+//
+//  Created:
+//    02 Nov 2023, 15:11:34
+//  Last edited:
+//    02 Nov 2023, 15:31:08
+//  Auto updated?
+//    Yes
+//
+//  Description:
+//!   Defines some utilities used in multiple places in this crate.
+//
+
+use std::fmt::{Display, Formatter, Result as FResult};
+use std::panic::catch_unwind;
+
+use brane_ast::ast;
+use brane_ast::state::VirtualSymTable;
+
+
+/***** FORMATTERS *****/
+/// A static formatter for a [`ProgramCounter`] that shows it nicer.
+#[derive(Clone, Debug)]
+pub struct PrettyProgramCounter(pub usize, pub usize, pub Option<String>);
+impl Display for PrettyProgramCounter {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        match &self.2 {
+            Some(name) => write!(f, "{}:{}", name, self.1),
+            None => write!(f, "{}:{}", self.0, self.1),
+        }
+    }
+}
+
+
+
+
+
+/***** LIBRARY FUNCTIONS *****/
+/// Gets a workflow edge from a PC.
+///
+/// # Arguments
+/// - `wir`: The [`ast::Workflow`] to get the edge from.
+/// - `pc`: The program counter that points to the edge (hopefully).
+///
+/// # Returns
+/// The edge the `pc` pointed to, or [`None`] if it was out-of-bounds.
+#[inline]
+pub fn get_edge(wir: &ast::Workflow, pc: impl AsRef<ProgramCounter>) -> Option<&ast::Edge> {
+    let pc: &ProgramCounter = pc.as_ref();
+    if pc.0 == usize::MAX { wir.graph.get(pc.1) } else { wir.funcs.get(&pc.0).map(|edges| edges.get(pc.1)).flatten() }
+}
+
+
+
+
+
+/***** LIBRARY *****/
+/// Abstracts over a program counter.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ProgramCounter(pub usize, pub usize);
+impl Default for ProgramCounter {
+    #[inline]
+    fn default() -> Self { Self::new() }
+}
+impl ProgramCounter {
+    /// Creates a new ProgramCounter that points to the start of a workflow.
+    ///
+    /// # Returns
+    /// Exactly what you expect, a ProgramCounter that, when used, points to the start of a workflow.
+    #[inline]
+    pub fn new() -> Self { Self(usize::MAX, 0) }
+
+    /// Creates a new ProgramCounter that points to the start of a new function.
+    ///
+    /// # Argumetns
+    /// - `func`: The function ID of the new function.
+    ///
+    /// # Returns
+    /// A new ProgramCounter that points to the start of the given function.
+    #[inline]
+    pub fn call(func: usize) -> Self { Self(func, 0) }
+
+    /// Creates a new ProgramCounter that points to the same function, next instruction.
+    ///
+    /// # Argumetns
+    /// - `idx`: The new index in the same instruction.
+    ///
+    /// # Returns
+    /// A new ProgramCounter that points to the given location in this function.
+    #[inline]
+    pub fn jump(&self, idx: usize) -> Self { Self(self.0, idx) }
+
+    /// Returns a formatter that shows the function resolved to a name if possible.
+    ///
+    /// # Returns
+    /// A [`PrettyProgramCounter`] that shows the name of the function indexed by `self.0` if known.
+    #[inline]
+    pub fn display(&self, table: &VirtualSymTable) -> PrettyProgramCounter {
+        // Attempt to find the function ID
+        if self.0 == usize::MAX {
+            PrettyProgramCounter(self.0, self.1, Some("<main>".into()))
+        } else if let Ok(def) = catch_unwind(|| table.func(self.0)) {
+            PrettyProgramCounter(self.0, self.1, Some(def.name.clone()))
+        } else {
+            PrettyProgramCounter(self.0, self.1, None)
+        }
+    }
+}
+impl AsRef<ProgramCounter> for ProgramCounter {
+    #[inline]
+    fn as_ref(&self) -> &Self { self }
+}
+impl AsMut<ProgramCounter> for ProgramCounter {
+    #[inline]
+    fn as_mut(&mut self) -> &mut Self { self }
+}
+impl From<&ProgramCounter> for ProgramCounter {
+    #[inline]
+    fn from(value: &Self) -> Self { *value }
+}
+impl From<&mut ProgramCounter> for ProgramCounter {
+    #[inline]
+    fn from(value: &mut Self) -> Self { *value }
+}
+impl From<(usize, usize)> for ProgramCounter {
+    #[inline]
+    fn from(value: (usize, usize)) -> Self { Self(value.0, value.1) }
+}
+impl From<ProgramCounter> for (usize, usize) {
+    #[inline]
+    fn from(value: ProgramCounter) -> Self { (value.0, value.1) }
+}

--- a/lib/workflow/src/utils.rs
+++ b/lib/workflow/src/utils.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    02 Nov 2023, 15:11:34
 //  Last edited:
-//    02 Nov 2023, 15:31:08
+//    08 Nov 2023, 10:06:25
 //  Auto updated?
 //    Yes
 //
@@ -16,7 +16,6 @@ use std::fmt::{Display, Formatter, Result as FResult};
 use std::panic::catch_unwind;
 
 use brane_ast::ast;
-use brane_ast::state::VirtualSymTable;
 
 
 /***** FORMATTERS *****/
@@ -97,7 +96,7 @@ impl ProgramCounter {
     /// # Returns
     /// A [`PrettyProgramCounter`] that shows the name of the function indexed by `self.0` if known.
     #[inline]
-    pub fn display(&self, table: &VirtualSymTable) -> PrettyProgramCounter {
+    pub fn display(&self, table: &ast::SymTable) -> PrettyProgramCounter {
         // Attempt to find the function ID
         if self.0 == usize::MAX {
             PrettyProgramCounter(self.0, self.1, Some("<main>".into()))

--- a/lib/workflow/src/visualize.rs
+++ b/lib/workflow/src/visualize.rs
@@ -4,7 +4,7 @@
 //  Created:
 //    31 Oct 2023, 14:30:00
 //  Last edited:
-//    02 Nov 2023, 14:46:43
+//    08 Nov 2023, 13:56:52
 //  Auto updated?
 //    Yes
 //
@@ -78,9 +78,10 @@ fn print_elem(f: &mut Formatter<'_>, elem: &'_ Elem, prefix: &dyn Display) -> FR
                 prefix,
                 write_iter!(
                     t.metadata.iter().map(|metadata| format!(
-                        "{}.{} ({}, {})",
-                        metadata.namespace,
+                        "{}.{} ({}:{}, {})",
+                        metadata.owner,
                         metadata.tag,
+                        metadata.assigner,
                         metadata.signature,
                         if let Some(valid) = metadata.signature_valid { if valid { "OK" } else { "invalid" } } else { "<not validated>" }
                     )),

--- a/tests/branescript/call.bs
+++ b/tests/branescript/call.bs
@@ -1,0 +1,11 @@
+// Test function calls
+
+println("Hello there!");
+println("General \" Kenobi,\n\tyou are a bold one!");
+
+func test() {
+    println("General Kenobi!!!");
+}
+
+test();
+test();

--- a/tests/branescript/call_chain.bs
+++ b/tests/branescript/call_chain.bs
@@ -1,0 +1,15 @@
+
+func foo() {
+    return "Foo";
+}
+func bar() {
+    return foo() + ",Bar";
+}
+func baz() {
+    return bar() + ",Baz";
+}
+func quz() {
+    return baz() + ",Quz";
+}
+
+println(quz());

--- a/tests/branescript/function.bs
+++ b/tests/branescript/function.bs
@@ -1,0 +1,18 @@
+// Test some function definitions
+func hello_there() {
+    println("Hello there!");
+}
+
+func say(text) {
+    println(text);
+}
+
+func add(lhs, rhs) {
+    let result := lhs + rhs;
+    return result;
+}
+
+
+hello_there();
+say("General Kenobi!");
+println(add(21, 21));

--- a/tests/branescript/scopes.bs
+++ b/tests/branescript/scopes.bs
@@ -1,0 +1,19 @@
+// Note: uncommenting te second works in full-workflow mode, but fails in REPL-mode. :(
+
+{
+    func test(text) {
+        print("Test123");
+        print(text);
+    }
+}
+// {
+//     func test(text) {
+//         print("Test321");
+//         print(text);
+//     }
+// }
+
+let i := 1;
+let j := i;
+
+// This should error when uncommented // let k := k; // And, fun-fact, these three comments should be allowed while at it >:( // Failed at doing that ;(

--- a/tests/branescript/task_chain.bs
+++ b/tests/branescript/task_chain.bs
@@ -1,0 +1,16 @@
+import hello_world;
+
+func once() {
+    return hello_world();
+}
+func twice() {
+    return once() + once();
+}
+func fours() {
+    return twice() + twice();
+}
+func eights() {
+    return fours() + fours();
+}
+
+println(eights());

--- a/tests/packages/test_data.yml
+++ b/tests/packages/test_data.yml
@@ -1,0 +1,40 @@
+# Defines a package that is used to test the data deduction
+
+# Define the file metadata
+name: data_test
+version: 1.0.0
+kind: ecu
+
+# Defines the file to call whenever a function is called
+entrypoint:
+  kind: task
+  exec: echo
+
+# Define the dependencies (as Ubuntu packages)
+dependencies:
+- fortune
+
+# Define the actions
+actions:
+  run_script:
+    command:
+      args:
+      - "result: \"/home/test/result.csv\""
+    input:
+    - name: dataset
+      type: IntermediateResult
+    output:
+    - name: result
+      type: IntermediateResult
+  aggregate:
+    command:
+      args:
+      - "global: \"/home/test/global.csv\""
+    input:
+    - name: local1
+      type: IntermediateResult
+    - name: local2
+      type: IntermediateResult
+    output:
+    - name: global
+      type: IntermediateResult


### PR DESCRIPTION
Removed the call-support from the checker workflow.

Accordingly, added preprocessing step that attempts to inline functions as much as possible before compilation.

Fixes #12