### PR TITLE
Dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,12 +3252,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
- "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -67,33 +67,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -190,7 +190,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -212,18 +212,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ dependencies = [
  "async-trait",
  "auth-resolver 0.1.0",
  "deliberation 0.1.0",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "hex",
  "policy 0.1.0",
  "serde",
@@ -263,12 +263,12 @@ dependencies = [
 [[package]]
 name = "audit-logger"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "async-trait",
  "auth-resolver 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "deliberation 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "hex",
  "policy 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "serde",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "auth-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "async-trait",
  "serde",
@@ -316,7 +316,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -406,15 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "blake2-rfc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,7 +437,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyperlocal",
  "log",
  "pin-project-lite",
@@ -475,13 +466,12 @@ dependencies = [
 [[package]]
 name = "brane-ast"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "brane-dsl",
  "brane-shr",
  "console",
- "enum-debug",
- "im",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "lazy_static",
  "log",
  "num-traits",
@@ -496,11 +486,10 @@ dependencies = [
 [[package]]
 name = "brane-cfg"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "async-trait",
- "brane-shr",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "log",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -514,14 +503,15 @@ dependencies = [
 [[package]]
 name = "brane-ctl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "base64ct",
  "bollard",
  "brane-cfg",
  "brane-shr",
  "brane-tsk",
- "clap 4.5.8",
+ "clap 4.5.13",
+ "clap_complete",
  "console",
  "dialoguer 0.11.0",
  "diesel",
@@ -530,11 +520,11 @@ dependencies = [
  "dotenvy",
  "download",
  "eflint-to-json 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
- "enum-debug",
- "error-trace",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
  "hex-literal",
  "human-panic",
- "humanlog",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "humantime",
  "jsonwebtoken",
  "lazy_static",
@@ -557,12 +547,11 @@ dependencies = [
 [[package]]
 name = "brane-dsl"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "brane-shr",
  "bytes",
- "enum-debug",
- "itertools 0.10.5",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "log",
  "nom",
  "nom_locate",
@@ -578,7 +567,7 @@ dependencies = [
 [[package]]
 name = "brane-exe"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -586,7 +575,7 @@ dependencies = [
  "brane-ast",
  "brane-shr",
  "console",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "futures",
  "lazy_static",
  "log",
@@ -601,19 +590,18 @@ dependencies = [
 [[package]]
 name = "brane-shr"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "async-compression",
  "console",
  "dialoguer 0.10.4",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "fs2",
  "futures-util",
  "hex",
- "humanlog",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "indicatif",
  "log",
- "num-derive",
  "num-traits",
  "regex",
  "reqwest 0.11.27",
@@ -628,7 +616,7 @@ dependencies = [
 [[package]]
 name = "brane-tsk"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -641,11 +629,10 @@ dependencies = [
  "chrono",
  "console",
  "dialoguer 0.11.0",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "futures-util",
  "graphql_client",
- "hex-literal",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "indicatif",
  "log",
  "num-traits",
@@ -685,15 +672,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -709,15 +696,15 @@ dependencies = [
  "brane-ast",
  "brane-shr",
  "chrono",
- "clap 4.5.8",
+ "clap 4.5.13",
  "console",
  "deliberation 0.1.0",
  "eflint-json",
  "eflint-to-json 0.1.0",
- "enum-debug",
- "error-trace",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
  "hmac",
- "humanlog",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "jwt",
  "log",
  "names",
@@ -742,7 +729,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -762,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -772,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -783,28 +770,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.5.8"
+name = "clap_complete"
+version = "4.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "a8670053e87c316345e384ca1f3eba3006fc6355ed8b8a1140d104e109e3df34"
+dependencies = [
+ "clap 4.5.13",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -915,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -925,27 +921,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -960,14 +956,14 @@ version = "0.1.0"
 dependencies = [
  "brane-ast",
  "brane-exe",
- "clap 4.5.8",
- "enum-debug",
- "error-trace",
- "humanlog",
+ "clap 4.5.13",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "serde",
  "serde_json",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
  "uuid",
  "workflow 0.3.0",
 ]
@@ -975,15 +971,15 @@ dependencies = [
 [[package]]
 name = "deliberation"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "brane-ast",
  "brane-exe",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "log",
  "serde",
  "serde_json",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs)",
  "uuid",
  "workflow 0.3.0",
 ]
@@ -1039,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d6dcd069e7b5fe49a302411f759d4cf1cf2c27fe798ef46fb8baefc053dd2b"
+checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
 dependencies = [
  "chrono",
  "diesel_derives",
@@ -1052,15 +1048,15 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59de76a222c2b8059f789cbe07afbfd8deb8c31dd0bc2a21f85e256c1def8259"
+checksum = "d6ff2be1e7312c858b2ef974f5c7089833ae57b5311b334b30923af58e5718d8"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1080,7 +1076,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1113,7 +1109,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1125,7 +1121,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "download"
 version = "0.1.0"
-source = "git+https://github.com/Lut99/download-rs#ebba70884249fcfcb978eef74c57da16b593ac33"
+source = "git+https://github.com/Lut99/download-rs?tag=v0.1.0#ebba70884249fcfcb978eef74c57da16b593ac33"
 dependencies = [
  "console",
  "hex",
@@ -1137,16 +1133,16 @@ dependencies = [
 
 [[package]]
 name = "dsl_auto_type"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0892a17df262a24294c382f0d5997571006e7a4348b4327557c4ff1cd4a8bccc"
+checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
 dependencies = [
  "darling",
  "either",
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1155,7 +1151,7 @@ version = "0.1.0"
 source = "git+https://gitlab.com/eflint/json-spec-rs?branch=incorrect-is-invariant#ec16789f8f697cf3edef32ea8f99ae73aea21ede"
 dependencies = [
  "console",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "lazy_static",
  "serde",
 ]
@@ -1179,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "eflint-to-json"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "async-recursion",
  "console",
@@ -1188,7 +1184,7 @@ dependencies = [
  "hex-literal",
  "indicatif",
  "log",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "sha2",
  "tokio",
 ]
@@ -1216,19 +1212,38 @@ dependencies = [
 
 [[package]]
 name = "enum-debug"
-version = "0.2.0"
-source = "git+https://github.com/Lut99/enum-debug#37066f5de14d541fb5603267ab1af98593213e4b"
+version = "1.0.0"
+source = "git+https://github.com/Lut99/enum-debug?tag=v1.0.0#cd67d67d4bd8708eaa3343a6af515bf6ad5a3ce6"
 dependencies = [
- "enum-debug-derive",
+ "enum-debug-derive 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+]
+
+[[package]]
+name = "enum-debug"
+version = "1.0.0"
+source = "git+https://github.com/Lut99/enum-debug#cd67d67d4bd8708eaa3343a6af515bf6ad5a3ce6"
+dependencies = [
+ "enum-debug-derive 1.0.0 (git+https://github.com/Lut99/enum-debug)",
 ]
 
 [[package]]
 name = "enum-debug-derive"
-version = "0.2.0"
-source = "git+https://github.com/Lut99/enum-debug#37066f5de14d541fb5603267ab1af98593213e4b"
+version = "1.0.0"
+source = "git+https://github.com/Lut99/enum-debug?tag=v1.0.0#cd67d67d4bd8708eaa3343a6af515bf6ad5a3ce6"
 dependencies = [
+ "proc-macro-error",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "enum-debug-derive"
+version = "1.0.0"
+source = "git+https://github.com/Lut99/enum-debug#cd67d67d4bd8708eaa3343a6af515bf6ad5a3ce6"
+dependencies = [
+ "proc-macro-error",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1249,8 +1264,13 @@ dependencies = [
 
 [[package]]
 name = "error-trace"
-version = "1.1.1"
-source = "git+https://github.com/Lut99/error-trace-rs#58bd7e59aa6c81a732e6df1a60118894f60b5633"
+version = "2.0.0"
+source = "git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0#7e9b76a2a2746a8ab88776877afd6ee53ea4b3b8"
+
+[[package]]
+name = "error-trace"
+version = "2.0.0"
+source = "git+https://github.com/Lut99/error-trace-rs#7e9b76a2a2746a8ab88776877afd6ee53ea4b3b8"
 
 [[package]]
 name = "failure"
@@ -1404,7 +1424,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1536,7 +1556,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1555,7 +1575,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1681,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1698,7 +1718,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1743,6 +1763,18 @@ dependencies = [
 [[package]]
 name = "humanlog"
 version = "0.1.0"
+source = "git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0#3c7a024de4e5822c44c0f2d1ae4b08806e500d03"
+dependencies = [
+ "atty",
+ "chrono",
+ "console",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
+name = "humanlog"
+version = "0.1.0"
 source = "git+https://github.com/Lut99/humanlog-rs#3c7a024de4e5822c44c0f2d1ae4b08806e500d03"
 dependencies = [
  "atty",
@@ -1760,9 +1792,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1784,16 +1816,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1810,7 +1842,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1824,9 +1856,9 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -1839,7 +1871,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1852,7 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1866,7 +1898,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1884,8 +1916,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1902,7 +1934,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "pin-project",
  "tokio",
 ]
@@ -1947,20 +1979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -2023,18 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2104,9 +2113,9 @@ name = "key-manager"
 version = "0.1.0"
 dependencies = [
  "brane-ctl",
- "clap 4.5.8",
- "error-trace",
- "humanlog",
+ "clap 4.5.13",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs)",
  "humantime",
  "jsonwebtoken",
  "log",
@@ -2126,9 +2135,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "d4588d65215825ee71ebff9e1c9982067833b1355d7546845ffdb3165cbd7456"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -2235,13 +2244,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2265,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "names"
 version = "0.1.0"
-source = "git+https://github.com/Lut99/names-rs#6fbb94733dfe526f7e68e374846e3802bac88327"
+source = "git+https://github.com/Lut99/names-rs?tag=v0.1.0#6fbb94733dfe526f7e68e374846e3802bac88327"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -2338,17 +2348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,16 +2363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
 ]
 
 [[package]]
@@ -2393,9 +2382,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -2417,9 +2406,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2438,7 +2427,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2458,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -2498,9 +2487,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2536,7 +2525,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2563,29 +2552,29 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "clap 4.5.8",
- "enum-debug",
- "error-trace",
- "humanlog",
+ "clap 4.5.13",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "serde",
  "serde_json",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
  "warp",
 ]
 
 [[package]]
 name = "policy"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "async-trait",
  "chrono",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "log",
  "serde",
  "serde_json",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs)",
  "warp",
 ]
 
@@ -2593,11 +2582,11 @@ dependencies = [
 name = "policy-builder"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.8",
+ "clap 4.5.13",
  "console",
  "eflint-to-json 0.1.0",
- "error-trace",
- "humanlog",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs)",
  "log",
 ]
 
@@ -2613,17 +2602,17 @@ dependencies = [
  "brane-cfg",
  "brane-shr",
  "chrono",
- "clap 4.5.8",
+ "clap 4.5.13",
  "deliberation 0.1.0",
  "diesel",
  "diesel_migrations",
  "dotenvy",
  "eflint-json",
  "eflint-to-json 0.1.0",
- "enum-debug",
- "error-trace",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
  "graphql_client",
- "humanlog",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "itertools 0.13.0",
  "jsonwebtoken",
  "log",
@@ -2647,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -2659,9 +2648,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "problem_details"
@@ -2672,6 +2664,30 @@ dependencies = [
  "http 0.2.12",
  "http-serde",
  "serde",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2703,16 +2719,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2794,15 +2801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,11 +2816,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "audit-logger 0.1.0",
- "clap 4.5.8",
+ "clap 4.5.13",
  "eflint-json",
- "enum-debug",
- "error-trace",
- "humanlog",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "policy 0.1.0",
  "reqwest 0.12.5",
@@ -2830,20 +2828,20 @@ dependencies = [
  "serde_json",
  "state-resolver 0.1.0",
  "tokio",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
  "workflow 0.1.0",
 ]
 
 [[package]]
 name = "reasonerconn"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "anyhow",
  "async-trait",
  "audit-logger 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "eflint-json",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "log",
  "policy 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "reqwest 0.12.5",
@@ -2851,7 +2849,7 @@ dependencies = [
  "serde_json",
  "state-resolver 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "tokio",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs)",
  "workflow 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
 ]
 
@@ -2881,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2943,7 +2941,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -2989,9 +2987,9 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -3078,13 +3076,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.6",
  "subtle",
  "zeroize",
 ]
@@ -3126,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3204,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -3217,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3233,31 +3231,32 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3280,14 +3279,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -3330,15 +3329,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.2"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079f3a42cd87588d924ed95b533f8d30a483388c4e400ab736a7058e34f16169"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3348,14 +3347,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.2"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc03aad67c1d26b7de277d51c86892e7d9a0110a2fe44bf6b26cc569fba302d6"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3376,7 +3375,7 @@ version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
  "libyml",
  "log",
@@ -3456,16 +3455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "specifications"
 version = "3.0.0"
-source = "git+https://github.com/epi-project/brane#b72fd2086acf99ed606c3c5ac7a8b6fa5f570ed9"
+source = "git+https://github.com/epi-project/brane#8de160daa3e1ca80a1ec18e9d79efe9d7ba2ba25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3501,21 +3490,19 @@ dependencies = [
  "base64ct",
  "chrono",
  "const_format",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "futures",
  "jsonwebtoken",
  "log",
  "num-traits",
  "parking_lot",
  "prost",
- "prost-types",
  "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_json",
- "serde_repr",
  "serde_test",
- "serde_with 3.8.2",
+ "serde_with 3.9.0",
  "serde_yml",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -3539,7 +3526,7 @@ dependencies = [
  "brane-exe",
  "chrono",
  "deliberation 0.1.0",
- "error-trace",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs)",
  "http 1.1.0",
  "log",
  "policy 0.1.0",
@@ -3558,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "srv"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "audit-logger 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
  "auth-resolver 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
@@ -3566,7 +3553,7 @@ dependencies = [
  "brane-exe",
  "chrono",
  "deliberation 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
- "error-trace",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs)",
  "http 1.1.0",
  "log",
  "policy 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
@@ -3594,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "state-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "async-trait",
  "serde",
@@ -3651,7 +3638,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3673,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3750,22 +3737,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3803,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3818,21 +3805,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3847,13 +3833,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3882,7 +3868,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3950,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3962,20 +3948,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3996,7 +3982,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4061,7 +4047,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4072,6 +4058,11 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "transform"
+version = "0.1.1"
+source = "git+https://github.com/Lut99/transform-rs?tag=v0.1.1#17d06ab4cf1bc2f8f25f2a8276159c2722cdf301"
 
 [[package]]
 name = "transform"
@@ -4197,9 +4188,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "rand 0.8.5",
@@ -4220,9 +4211,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -4260,7 +4251,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "mime",
  "mime_guess",
@@ -4305,7 +4296,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -4339,7 +4330,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4410,7 +4401,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4428,7 +4419,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4448,18 +4439,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4470,9 +4461,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4482,9 +4473,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4494,15 +4485,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4512,9 +4503,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4524,9 +4515,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4536,9 +4527,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4548,15 +4539,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -4588,11 +4579,11 @@ dependencies = [
  "brane-ast",
  "brane-exe",
  "brane-shr",
- "clap 4.5.8",
+ "clap 4.5.13",
  "eflint-json",
- "enum-debug",
- "error-trace",
- "humanlog",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
+ "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "names",
  "num-traits",
@@ -4600,24 +4591,24 @@ dependencies = [
  "serde",
  "serde_json",
  "specifications",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
 ]
 
 [[package]]
 name = "workflow"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#7566f131bfd65db2cd6775b579d59687a5162f6b"
+source = "git+https://github.com/epi-project/policy-reasoner#9dfd53b9c6a3b8f2e99ea1ca75e62373494f0d21"
 dependencies = [
  "brane-ast",
  "brane-exe",
  "eflint-json",
- "enum-debug",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "log",
  "num-traits",
  "rand 0.8.5",
  "serde",
  "specifications",
- "transform",
+ "transform 0.1.1 (git+https://github.com/Lut99/transform-rs)",
 ]
 
 [[package]]
@@ -4669,6 +4660,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,7 +4617,7 @@ dependencies = [
  "brane-ast",
  "brane-exe",
  "eflint-json",
- "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
+ "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug)",
  "log",
  "num-traits",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,9 +963,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
  "uuid",
- "workflow 0.3.0",
 ]
 
 [[package]]
@@ -2553,13 +2551,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 4.5.13",
- "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",
  "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "serde",
  "serde_json",
- "transform 0.1.1 (git+https://github.com/Lut99/transform-rs?tag=v0.1.1)",
  "warp",
 ]
 
@@ -2823,7 +2819,6 @@ dependencies = [
  "humanlog 0.1.0 (git+https://github.com/Lut99/humanlog-rs?tag=v0.1.0)",
  "log",
  "policy 0.1.0",
- "reqwest 0.12.5",
  "serde",
  "serde_json",
  "state-resolver 0.1.0",
@@ -3536,7 +3531,6 @@ dependencies = [
  "serde_json",
  "state-resolver 0.1.0",
  "tokio",
- "tokio-scoped",
  "uuid",
  "warp",
  "workflow 0.1.0",
@@ -4579,7 +4573,6 @@ dependencies = [
  "brane-ast",
  "brane-exe",
  "brane-shr",
- "clap 4.5.13",
  "eflint-json",
  "enum-debug 1.0.0 (git+https://github.com/Lut99/enum-debug?tag=v1.0.0)",
  "error-trace 2.0.0 (git+https://github.com/Lut99/error-trace-rs?tag=v2.0.0)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
- "serde_yml",
+ "serde_yml 0.0.10",
  "specifications",
  "tokio",
  "x509-parser",
@@ -536,7 +536,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yml 0.0.10",
  "shlex",
  "specifications",
  "srv 0.1.0 (git+https://github.com/epi-project/policy-reasoner)",
@@ -642,7 +642,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yml 0.0.10",
  "sha2",
  "specifications",
  "tokio",
@@ -2148,6 +2148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
 
 [[package]]
+name = "libyml"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64804cc6a5042d4f05379909ba25b503ec04e2c082151d62122d5dcaa274b961"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,7 +2624,7 @@ dependencies = [
  "reqwest 0.12.5",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yml 0.0.11",
  "sha2",
  "specifications",
  "srv 0.1.0",
@@ -3372,7 +3378,24 @@ checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
 dependencies = [
  "indexmap 2.3.0",
  "itoa",
- "libyml",
+ "libyml 0.0.3",
+ "log",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e76bab63c3fd98d27c17f9cbce177f64a91f5e69ac04cafe04e1bb25d1dc3c"
+dependencies = [
+ "indexmap 2.3.0",
+ "itoa",
+ "libyml 0.0.4",
  "log",
  "memchr",
  "ryu",
@@ -3498,7 +3521,7 @@ dependencies = [
  "serde_json",
  "serde_test",
  "serde_with 3.9.0",
- "serde_yml",
+ "serde_yml 0.0.10",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ repository = "https://github.com/epi-project/policy-reasoner"
 async-trait = "0.1.67"
 base64ct = { version = "1.6", features = ["std"] }
 chrono = "0.4.35"
-clap = { version = "4.4.0", features = ["derive", "env"] }
+clap = { version = "4.5.6", features = ["derive", "env"] }
 diesel = { version = "2.2.0", features = ["sqlite", "chrono", "r2d2"] }
 dotenvy = "0.15.7"
 itertools = "0.13.0"
 jsonwebtoken = "9.2.0"
-log = "0.4.21"
+log = "0.4.22"
 reqwest = { version = "0.12.0", features = ["json"] }
-serde = { version="1.0.203", features=["derive"]}
-serde_json = { version = "1.0.117" , features = ["raw_value"]}
+serde = { version="1.0.204", features=["derive"]}
+serde_json = { version = "1.0.120" , features = ["raw_value"]}
 serde_yaml = { version = "0.0.11", package = "serde_yml" }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,49 +12,59 @@ repository = "https://github.com/epi-project/policy-reasoner"
 
 
 [dependencies]
+# Crates.io
+async-trait = "0.1.67"
 base64ct = { version = "1.6", features = ["std"] }
+chrono = "0.4.35"
 clap = { version = "4.4.0", features = ["derive", "env"] }
-tokio = { version = "1.38.0", features = ["full"] }
-workflow = { path = "./lib/workflow" }
-deliberation = { path = "./lib/deliberation" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
+diesel = { version = "2.2.0", features = ["sqlite", "chrono", "r2d2"] }
+dotenvy = "0.15.7"
+itertools = "0.13.0"
+jsonwebtoken = "9.2.0"
 log = "0.4.21"
-reasonerconn = { path = "./lib/reasonerconn" }
+reqwest = { version = "0.12.0", features = ["json"] }
+serde = { version="1.0.203", features=["derive"]}
+serde_json = { version = "1.0.117" , features = ["raw_value"]}
+serde_yaml = { version = "0.0.10", package = "serde_yml" }
+thiserror = "1.0.61"
+tokio = { version = "1.38.0", features = ["full"] }
+uuid = { version = "1.7.0", features = ["serde", "v4"], optional = true }
+warp = "0.3"
+
+# Path
+audit-logger = { path = "lib/audit-logger"}
+auth-resolver = { path = "lib/auth-resolver"}
+deliberation = { path = "./lib/deliberation" }
+nested-cli-parser = { path = "lib/nested-cli-parser" }
 policy = { path = "./lib/policy" }
-eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant" }
+reasonerconn = { path = "./lib/reasonerconn" }
 srv = { path = "lib/srv" }
 state-resolver = { path = "lib/state-resolver" }
-auth-resolver = {path = "lib/auth-resolver"}
-audit-logger = {path = "lib/audit-logger"}
-async-trait = "0.1.67"
-serde = {version="1.0.203", features=["derive"]}
-serde_json = {version = "1.0.117" , features = ["raw_value"]}
-serde_yaml = { version = "0.0.10", package = "serde_yml" }
-warp = "0.3"
-chrono = "0.4.35"
-diesel = { version = "2.2.0", features = ["sqlite", "chrono", "r2d2"] }
-jsonwebtoken = "9.2.0"
-reqwest = { version = "0.12.0", features = ["json"] }
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-graphql_client = { version = "0.13", optional = true }
-nested-cli-parser = { path = "lib/nested-cli-parser" }
+workflow = { path = "./lib/workflow" }
+
+# GitHub
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }
+
+# GitLab
+eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant" }
+
+# Brane
 brane-cfg = { git = "https://github.com/epi-project/brane", optional = true }
-specifications = { git = "https://github.com/epi-project/brane" }
-uuid = { version = "1.7.0", features = ["serde", "v4"], optional = true }
 brane-shr = { git = "https://github.com/epi-project/brane" }
-itertools = "0.13.0"
-thiserror = "1.0.61"
-dotenvy = "0.15.7"
+specifications = { git = "https://github.com/epi-project/brane" }
+
+# Weird
+graphql_client = { version = "0.13", optional = true }
 
 
 [build-dependencies]
 base16ct = { version = "0.2", features = ["alloc"] }
 diesel = { version = "2.2.0", default-features = false, features = ["sqlite"] }
 diesel_migrations = "2.2.0"
-# download = { git = "https://github.com/Lut99/download-rs", default-features = false, features = ["download", "tar"] }
 eflint-to-json = { path = "./lib/eflint-to-json" }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
 sha2 = "0.10.6"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.21"
 reqwest = { version = "0.12.0", features = ["json"] }
 serde = { version="1.0.203", features=["derive"]}
 serde_json = { version = "1.0.117" , features = ["raw_value"]}
-serde_yaml = { version = "0.0.10", package = "serde_yml" }
+serde_yaml = { version = "0.0.11", package = "serde_yml" }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["full"] }
 uuid = { version = "1.7.0", features = ["serde", "v4"], optional = true }

--- a/lib/audit-logger/Cargo.toml
+++ b/lib/audit-logger/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 # Crates.io
 async-trait = "0.1.67"
 hex = "0.4.3"
-serde = "1.0.203"
-serde_json = "1.0.117"
+serde = "1.0.204"
+serde_json = "1.0.120"
 warp = "0.3"
 
 # Path

--- a/lib/audit-logger/Cargo.toml
+++ b/lib/audit-logger/Cargo.toml
@@ -7,14 +7,19 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Crates.io
 async-trait = "0.1.67"
-auth-resolver = {path = "../auth-resolver"}
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-policy = {path = "../policy"}
-deliberation = {path = "../deliberation"}
-state-resolver = {path = "../state-resolver"}
-workflow = {path = "../workflow"}
+hex = "0.4.3"
 serde = "1.0.203"
 serde_json = "1.0.117"
 warp = "0.3"
-hex = "0.4.3"
+
+# Path
+auth-resolver = { path = "../auth-resolver" }
+deliberation = { path = "../deliberation" }
+policy = { path = "../policy" }
+state-resolver = { path = "../state-resolver" }
+workflow = { path = "../workflow" }
+
+# Git
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }

--- a/lib/auth-resolver/Cargo.toml
+++ b/lib/auth-resolver/Cargo.toml
@@ -8,5 +8,5 @@ repository.workspace = true
 
 [dependencies]
 async-trait = "0.1.67"
-serde = { version = "1.0.203", features = ["derive"] }
+serde = { version = "1.0.204", features = ["derive"] }
 warp = "0.3"

--- a/lib/deliberation/Cargo.toml
+++ b/lib/deliberation/Cargo.toml
@@ -13,11 +13,9 @@ log = "0.4.21"
 serde = { version="1.0.203", features=["derive"] }
 serde_json = "1.0.117"
 uuid = "1.7.0"
-workflow = "0.3"
 
 # Git
 enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
-transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
 
 # Brane
 brane-ast = { git = "https://github.com/epi-project/brane" }

--- a/lib/deliberation/Cargo.toml
+++ b/lib/deliberation/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 
 [dependencies]
 # Crates.io
-log = "0.4.21"
-serde = { version="1.0.203", features=["derive"] }
-serde_json = "1.0.117"
+log = "0.4.22"
+serde = { version="1.0.204", features=["derive"] }
+serde_json = "1.0.120"
 uuid = "1.7.0"
 
 # Git
@@ -24,8 +24,8 @@ brane-exe = { git = "https://github.com/epi-project/brane" }
 
 [dev-dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
-log = "0.4.21"
+clap = { version = "4.5.6", features = ["derive"] }
+log = "0.4.22"
 
 # Git
 error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }

--- a/lib/deliberation/Cargo.toml
+++ b/lib/deliberation/Cargo.toml
@@ -8,19 +8,27 @@ repository.workspace = true
 
 
 [dependencies]
-brane-ast = { git = "https://github.com/epi-project/brane" }
-brane-exe = { git = "https://github.com/epi-project/brane" }
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
+# Crates.io
 log = "0.4.21"
-serde = {version="1.0.203", features=["derive"]}
+serde = { version="1.0.203", features=["derive"] }
 serde_json = "1.0.117"
-transform = { git = "https://github.com/Lut99/transform-rs" }
 uuid = "1.7.0"
 workflow = "0.3"
 
+# Git
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
+
+# Brane
+brane-ast = { git = "https://github.com/epi-project/brane" }
+brane-exe = { git = "https://github.com/epi-project/brane" }
+
 
 [dev-dependencies]
+# Crates.io
 clap = { version = "4.4.0", features = ["derive"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 log = "0.4.21"
+
+# Git
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }

--- a/lib/eflint-to-json/Cargo.toml
+++ b/lib/eflint-to-json/Cargo.toml
@@ -14,7 +14,7 @@ futures-util = "0.3.30"
 hex = "0.4.3"
 hex-literal = "0.4"
 indicatif = "0.17"
-log = "0.4.21"
+log = "0.4.22"
 reqwest = { version = "0.12.0", features = ["blocking", "stream"] }
 sha2 = "0.10.6"
 tokio = { version = "1.38.0", default-features = false, features = ["fs", "process"]}

--- a/lib/policy/Cargo.toml
+++ b/lib/policy/Cargo.toml
@@ -8,18 +8,23 @@ repository.workspace = true
 
 
 [dependencies]
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-log = "0.4.21"
-transform = { git = "https://github.com/Lut99/transform-rs" }
+# Crates.io
+async-trait = "0.1.67"
 chrono = { version = "0.4.35", features=["serde"] }
+log = "0.4.21"
 serde = {version="1.0.203", features=["derive"]}
 serde_json = {version = "1.0.117" , features = ["raw_value"]}
-async-trait = "0.1.67"
 warp = "0.3"
 
+# Git
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
+
 [dev-dependencies]
+# Crates.io
 clap = { version = "4.4.0", features = ["derive"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 log = "0.4.21"
 
+# Git
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }

--- a/lib/policy/Cargo.toml
+++ b/lib/policy/Cargo.toml
@@ -16,10 +16,6 @@ serde = {version="1.0.203", features=["derive"]}
 serde_json = {version = "1.0.117" , features = ["raw_value"]}
 warp = "0.3"
 
-# Git
-enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
-transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
-
 [dev-dependencies]
 # Crates.io
 clap = { version = "4.4.0", features = ["derive"] }

--- a/lib/policy/Cargo.toml
+++ b/lib/policy/Cargo.toml
@@ -11,15 +11,15 @@ repository.workspace = true
 # Crates.io
 async-trait = "0.1.67"
 chrono = { version = "0.4.35", features=["serde"] }
-log = "0.4.21"
-serde = {version="1.0.203", features=["derive"]}
-serde_json = {version = "1.0.117" , features = ["raw_value"]}
+log = "0.4.22"
+serde = {version="1.0.204", features=["derive"]}
+serde_json = {version = "1.0.120" , features = ["raw_value"]}
 warp = "0.3"
 
 [dev-dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
-log = "0.4.21"
+clap = { version = "4.5.6", features = ["derive"] }
+log = "0.4.22"
 
 # Git
 error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }

--- a/lib/reasonerconn/Cargo.toml
+++ b/lib/reasonerconn/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.67"
 log = "0.4.21"
-reqwest = { version = "0.12.0", features = ["blocking"] }
 serde = { version="1.0.203", features=["derive"] }
 serde_json = { version = "1.0.117" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }

--- a/lib/reasonerconn/Cargo.toml
+++ b/lib/reasonerconn/Cargo.toml
@@ -11,9 +11,9 @@ repository.workspace = true
 # Crates.io
 anyhow = "1.0.66"
 async-trait = "0.1.67"
-log = "0.4.21"
-serde = { version="1.0.203", features=["derive"] }
-serde_json = { version = "1.0.117" , features = ["raw_value"] }
+log = "0.4.22"
+serde = { version="1.0.204", features=["derive"] }
+serde_json = { version = "1.0.120" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }
 
 # Path
@@ -30,8 +30,8 @@ transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
 
 [dev-dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
-log = "0.4.21"
+clap = { version = "4.5.6", features = ["derive"] }
+log = "0.4.22"
 
 # Git
 error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }

--- a/lib/reasonerconn/Cargo.toml
+++ b/lib/reasonerconn/Cargo.toml
@@ -8,24 +8,32 @@ repository.workspace = true
 
 
 [dependencies]
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-log = "0.4.21"
-transform = { git = "https://github.com/Lut99/transform-rs" }
-policy = { path = "../policy" }
-workflow = { path = "../workflow", features = ["eflint"]}
-state-resolver = { path = "../state-resolver" }
-audit-logger = { path = "../audit-logger" }
-eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant" }
-reqwest = {version = "0.12.0", features = ["blocking"]}
+# Crates.io
 anyhow = "1.0.66"
-serde = {version="1.0.203", features=["derive"]}
-serde_json = {version = "1.0.117" , features = ["raw_value"]}
 async-trait = "0.1.67"
+log = "0.4.21"
+reqwest = { version = "0.12.0", features = ["blocking"] }
+serde = { version="1.0.203", features=["derive"] }
+serde_json = { version = "1.0.117" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }
+
+# Path
+audit-logger = { path = "../audit-logger" }
+policy = { path = "../policy" }
+state-resolver = { path = "../state-resolver" }
+workflow = { path = "../workflow", features = ["eflint"]}
+
+# Git
+eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant" }
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
 
 
 [dev-dependencies]
+# Crates.io
 clap = { version = "4.4.0", features = ["derive"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 log = "0.4.21"
+
+# Git
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }

--- a/lib/srv/Cargo.toml
+++ b/lib/srv/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 # Crates.io
 chrono = "0.4.35"
 http = "1.0.0"
-log = "0.4.21"
+log = "0.4.22"
 problem_details = "0.5.1"
-serde = { version="1.0.203", features=["derive"] }
-serde_json = {version = "1.0.117" , features = ["raw_value"] }
+serde = { version="1.0.204", features=["derive"] }
+serde_json = {version = "1.0.120" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }
 uuid = { version="1.7.0", features = ["v4"] }
 warp = "0.3"

--- a/lib/srv/Cargo.toml
+++ b/lib/srv/Cargo.toml
@@ -15,7 +15,6 @@ problem_details = "0.5.1"
 serde = { version="1.0.203", features=["derive"] }
 serde_json = {version = "1.0.117" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }
-tokio-scoped = "0.2"
 uuid = { version="1.7.0", features = ["v4"] }
 warp = "0.3"
 

--- a/lib/srv/Cargo.toml
+++ b/lib/srv/Cargo.toml
@@ -7,23 +7,30 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-audit-logger = { path = "../audit-logger" }
-auth-resolver = { path = "../auth-resolver" }
-brane-ast = { git = "https://github.com/epi-project/brane" }
-brane-exe = { git = "https://github.com/epi-project/brane" }
+# Crates.io
 chrono = "0.4.35"
-deliberation = { path = "../deliberation" }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 http = "1.0.0"
 log = "0.4.21"
-reasonerconn = {path = "../reasonerconn"}
-policy = { path = "../policy" }
 problem_details = "0.5.1"
-serde = {version="1.0.203", features=["derive"]}
-serde_json = {version = "1.0.117" , features = ["raw_value"]}
-state-resolver = { path = "../state-resolver" }
+serde = { version="1.0.203", features=["derive"] }
+serde_json = {version = "1.0.117" , features = ["raw_value"] }
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-scoped = "0.2"
-uuid ={version="1.7.0", features = ["v4"]}
-workflow = { path = "../workflow" }
+uuid = { version="1.7.0", features = ["v4"] }
 warp = "0.3"
+
+# Path
+audit-logger = { path = "../audit-logger" }
+auth-resolver = { path = "../auth-resolver" }
+deliberation = { path = "../deliberation" }
+policy = { path = "../policy" }
+reasonerconn = {path = "../reasonerconn"}
+state-resolver = { path = "../state-resolver" }
+workflow = { path = "../workflow" }
+
+# Git
+error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
+
+# Brane
+brane-ast = { git = "https://github.com/epi-project/brane" }
+brane-exe = { git = "https://github.com/epi-project/brane" }

--- a/lib/state-resolver/Cargo.toml
+++ b/lib/state-resolver/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Crates.io
 async-trait = "0.1.67"
-serde = {version="1.0.203", features=["derive"]}
+serde = { version="1.0.203", features=["derive"] }
+
+# Path
 workflow = {path = "../workflow"}

--- a/lib/state-resolver/Cargo.toml
+++ b/lib/state-resolver/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 # Crates.io
 async-trait = "0.1.67"
-serde = { version="1.0.203", features=["derive"] }
+serde = { version="1.0.204", features=["derive"] }
 
 # Path
 workflow = {path = "../workflow"}

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -8,28 +8,36 @@ repository.workspace = true
 
 
 [dependencies]
-eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", optional = true }
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
+# Crates.io
+clap = { version = "4.4.0", features = ["derive"] }
 log = "0.4.21"
 num-traits = "0.2.18"
 rand = "0.8.5"
 serde = { version = "1.0.203", features = ["derive"] }
-transform = { git = "https://github.com/Lut99/transform-rs" }
 
+# Git
+eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", optional = true }
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.1.1" }
+
+# Brane
 brane-ast = { git = "https://github.com/epi-project/brane" }
 brane-exe = { git = "https://github.com/epi-project/brane" }
 specifications = { git = "https://github.com/epi-project/brane" }
 
 
 [dev-dependencies]
-clap = { version = "4.4.0", features = ["derive"] }
-eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", features = ["display_eflint"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
+# Crates
 log = "0.4.21"
-names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = ["rand", "three-usualcase"] }
 serde_json = "1.0.117"
 
+# Git
+eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", features = ["display_eflint"] }
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }
+names = { git = "https://github.com/Lut99/names-rs", tag = "v0.1.0", default-features = false, features = ["rand", "three-usualcase"] }
+
+# Brane
 brane-shr = { git = "https://github.com/epi-project/brane" }
 
 

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 
 [dependencies]
 # Crates.io
-log = "0.4.21"
+log = "0.4.22"
 num-traits = "0.2.18"
 rand = "0.8.5"
-serde = { version = "1.0.203", features = ["derive"] }
+serde = { version = "1.0.204", features = ["derive"] }
 
 # Git
 eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", optional = true }
@@ -27,8 +27,8 @@ specifications = { git = "https://github.com/epi-project/brane" }
 
 [dev-dependencies]
 # Crates
-log = "0.4.21"
-serde_json = "1.0.117"
+log = "0.4.22"
+serde_json = "1.0.120"
 
 # Git
 eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", features = ["display_eflint"] }

--- a/lib/workflow/Cargo.toml
+++ b/lib/workflow/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 
 [dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
 log = "0.4.21"
 num-traits = "0.2.18"
 rand = "0.8.5"

--- a/tools/checker-client/Cargo.toml
+++ b/tools/checker-client/Cargo.toml
@@ -10,14 +10,14 @@ description = "A tool to make requests to the checker conveniently, for demo/tes
 [dependencies]
 # Crates.io
 chrono = "0.4.35"
-clap = { version = "4.4.0", features = ["derive"] }
+clap = { version = "4.5.6", features = ["derive"] }
 console = "0.15.5"
 hmac = "0.12"
 jwt = "0.16"
-log = "0.4.21"
+log = "0.4.22"
 rand = "0.8.5"
 reqwest = { version = "0.12.0", features = ["blocking"] }
-serde_json = { version = "1.0.117", features = ["raw_value"] }
+serde_json = { version = "1.0.120", features = ["raw_value"] }
 sha2 = "0.10.6"
 
 # Path

--- a/tools/checker-client/Cargo.toml
+++ b/tools/checker-client/Cargo.toml
@@ -8,27 +8,33 @@ description = "A tool to make requests to the checker conveniently, for demo/tes
 
 
 [dependencies]
-brane-ast = { git = "https://github.com/epi-project/brane" }
-brane-shr = { git = "https://github.com/epi-project/brane" }
+# Crates.io
 chrono = "0.4.35"
 clap = { version = "4.4.0", features = ["derive"] }
 console = "0.15.5"
-specifications = { git = "https://github.com/epi-project/brane" }
-eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", features = ["display_eflint"] }
-enum-debug = { git = "https://github.com/Lut99/enum-debug", features = ["derive"] }
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 hmac = "0.12"
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 jwt = "0.16"
 log = "0.4.21"
-names = { git = "https://github.com/Lut99/names-rs", default-features = false, features = ["rand", "three-usualcase"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.0", features = ["blocking"] }
 serde_json = { version = "1.0.117", features = ["raw_value"] }
 sha2 = "0.10.6"
 
+# Path
 audit-logger = { path = "../../lib/audit-logger" }
 deliberation = { path = "../../lib/deliberation" }
 eflint-to-json = { path = "../../lib/eflint-to-json" }
 policy = { path = "../../lib/policy" }
 srv = { path = "../../lib/srv" }
+
+# Git
+eflint-json = { git = "https://gitlab.com/eflint/json-spec-rs", branch = "incorrect-is-invariant", features = ["display_eflint"] }
+enum-debug = { git = "https://github.com/Lut99/enum-debug", tag = "v1.0.0", features = ["derive"] }
+error-trace = { git = "https://github.com/Lut99/error-trace-rs", tag = "v2.0.0" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs", tag = "v0.1.0" }
+names = { git = "https://github.com/Lut99/names-rs", tag = "v0.1.0", default-features = false, features = ["rand", "three-usualcase"] }
+
+# Brane
+brane-ast = { git = "https://github.com/epi-project/brane" }
+brane-shr = { git = "https://github.com/epi-project/brane" }
+specifications = { git = "https://github.com/epi-project/brane" }

--- a/tools/key-manager/Cargo.toml
+++ b/tools/key-manager/Cargo.toml
@@ -8,10 +8,13 @@ description = "A tool that copies `branectl`s behaviour in making it easy to gen
 
 
 [dependencies]
-brane-ctl = { git = "https://github.com/epi-project/brane" }
+# Crates.io
 clap = { version = "4.4.0", features = ["derive"] }
+humantime = "2.1"
+jsonwebtoken = "9.2.0"
+log = "0.4.21"
+
+# Git
+brane-ctl = { git = "https://github.com/epi-project/brane" }
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
 humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
-humantime = "2.1"
-log = "0.4.21"
-jsonwebtoken = "9.2.0"

--- a/tools/key-manager/Cargo.toml
+++ b/tools/key-manager/Cargo.toml
@@ -9,10 +9,10 @@ description = "A tool that copies `branectl`s behaviour in making it easy to gen
 
 [dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
+clap = { version = "4.5.6", features = ["derive"] }
 humantime = "2.1"
 jsonwebtoken = "9.2.0"
-log = "0.4.21"
+log = "0.4.22"
 
 # Git
 brane-ctl = { git = "https://github.com/epi-project/brane" }

--- a/tools/policy-builder/Cargo.toml
+++ b/tools/policy-builder/Cargo.toml
@@ -8,9 +8,9 @@ description = "Tool for taking a collection of eFLINT files and compiling them t
 
 [dependencies]
 # Crates.io
-clap = { version = "4.4.0", features = ["derive"] }
+clap = { version = "4.5.6", features = ["derive"] }
 console = "0.15.5"
-log = "0.4.21"
+log = "0.4.22"
 
 # Git
 error-trace = { git = "https://github.com/Lut99/error-trace-rs" }

--- a/tools/policy-builder/Cargo.toml
+++ b/tools/policy-builder/Cargo.toml
@@ -7,10 +7,14 @@ description = "Tool for taking a collection of eFLINT files and compiling them t
 
 
 [dependencies]
-clap = { version = "4.4.0", features = ["derive"]}
+# Crates.io
+clap = { version = "4.4.0", features = ["derive"] }
 console = "0.15.5"
-error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
-humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
 log = "0.4.21"
 
+# Git
+error-trace = { git = "https://github.com/Lut99/error-trace-rs" }
+humanlog = { git = "https://github.com/Lut99/humanlog-rs" }
+
+# Path
 eflint-to-json = { path = "../../lib/eflint-to-json" }


### PR DESCRIPTION
Okay, here a couple of commits to clean up all the dependencies.

The whole enum-debug version mismatch problem was a giant headache today, but I hope that pinning and structuring the dependencies might make everything more reliable.

~Okay, I have no clue right now why CI fails. It works locally for me. I'll get back to that on Monday~ That is fixed

I also bumped the minimal versions, as of course they changed a fair bit with these updates. We will also probably need to do another round of that for Brane again :(

For the CI, it is impossible to get CI to pass right now, as the problem is that the current main branch (which is pulled in by `brane-ctl`) is broken. These commits will hopefully fix that, but they would have to be merged for that to take effect.

EDIT: To clarify, the main problem is that we transitively depend on ourselves via Brane, so if we break main here any PR will inevitably also fail.