### PR TITLE
fix: Define common interface for all reasoners

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,14 @@ The entry point for the library is `src/lib.rs` as per usual.
 In these files no particular implementation of a policy reasoner is included, only
 the mechanisms on which the concept of a policy reasoner can be implemented.
 
+### Interface
+
+The interface for the different reasoners must be the same. Its command line
+arguments are defined in `src/bin/implementation/interface.rs`. It could be that a new
+reasoner requires more arguments. You can implement another arguments struct, however
+make sure the arguments defined in the common interface are supported as other
+components of infrastructure may depend on it.
+
 ### Implementations
 
 As of now there are three different implementations of a policy reasoners in

--- a/src/bin/eflint.rs
+++ b/src/bin/eflint.rs
@@ -16,7 +16,6 @@ pub mod implementation;
 
 use std::env;
 use std::fs::File;
-use std::net::SocketAddr;
 
 use clap::Parser;
 use error_trace::ErrorTrace as _;
@@ -26,6 +25,7 @@ use implementation::eflint::EFlintLeakNoErrors;
 #[cfg(feature = "leak-public-errors")]
 use implementation::eflint::EFlintLeakPrefixErrors;
 use implementation::eflint::EFlintReasonerConnector;
+use implementation::interface::Arguments;
 use log::{error, info};
 use policy_reasoner::auth::{JwtConfig, JwtResolver, KidResolver};
 use policy_reasoner::logger::FileLogger;
@@ -44,43 +44,6 @@ fn get_dauth_resolver() -> JwtResolver<KidResolver> {
     let r = File::open("./examples/config/jwt_resolver.yaml").unwrap();
     let jwt_cfg: JwtConfig = serde_yaml::from_reader(r).unwrap();
     JwtResolver::new(jwt_cfg, kid_resolver).unwrap()
-}
-
-/***** ARGUMENTS *****/
-/// Defines the arguments for the `policy-reasoner` server.
-#[derive(Debug, Parser)]
-struct Arguments {
-    /// Whether to enable full debugging
-    #[clap(long, global = true, help = "If given, enables more verbose debugging.")]
-    trace: bool,
-
-    /// The address on which to bind ourselves.
-    #[clap(short, long, env, default_value = "127.0.0.1:3030", help = "The address on which to bind the server.")]
-    address: SocketAddr,
-
-    /// Shows the help menu for the state resolver.
-    #[clap(long, help = "If given, shows the possible arguments to pass to the state resolver plugin in '--state-resolver'.")]
-    help_state_resolver: bool,
-    /// Arguments specific to the state resolver.
-    #[clap(
-        short,
-        long,
-        env,
-        help = "Arguments to pass to the current state resolver plugin. To find which are possible, see '--help-state-resolver'."
-    )]
-    state_resolver:      Option<String>,
-
-    /// Shows the help menu for the reasoner connector.
-    #[clap(long, help = "If given, shows the possible arguments to pass to the reasoner connector plugin in '--reasoner-connector'.")]
-    help_reasoner_connector: bool,
-    /// Arguments specific to the state resolver.
-    #[clap(
-        short,
-        long,
-        env,
-        help = "Arguments to pass to the current reasoner connector plugin. To find which are possible, see '--help-reasoner-connector'."
-    )]
-    reasoner_connector:      Option<String>,
 }
 
 /***** PLUGINS *****/

--- a/src/bin/implementation/interface.rs
+++ b/src/bin/implementation/interface.rs
@@ -1,0 +1,42 @@
+use std::net::SocketAddr;
+
+use clap::Parser;
+
+/***** ARGUMENTS *****/
+/// Defines the arguments for the `policy-reasoner` server.
+#[derive(Debug, Parser)]
+pub struct Arguments {
+    /// Whether to enable full debugging
+    #[clap(long, global = true, help = "If given, enables more verbose debugging.")]
+    pub trace: bool,
+
+    /// The address on which to bind ourselves.
+    #[clap(short, long, env, default_value = "127.0.0.1:3030", help = "The address on which to bind the server.")]
+    pub address: SocketAddr,
+
+    /// Shows the help menu for the state resolver.
+    #[clap(long, help = "If given, shows the possible arguments to pass to the state resolver plugin in '--state-resolver'.")]
+    pub help_state_resolver: bool,
+
+    /// Arguments specific to the state resolver.
+    #[clap(
+        short,
+        long,
+        env,
+        help = "Arguments to pass to the current state resolver plugin. To find which are possible, see '--help-state-resolver'."
+    )]
+    pub state_resolver: Option<String>,
+
+    /// Shows the help menu for the reasoner connector.
+    #[clap(long, help = "If given, shows the possible arguments to pass to the reasoner connector plugin in '--reasoner-connector'.")]
+    pub help_reasoner_connector: bool,
+
+    /// Arguments specific to the state resolver.
+    #[clap(
+        short,
+        long,
+        env,
+        help = "Arguments to pass to the current reasoner connector plugin. To find which are possible, see '--help-reasoner-connector'."
+    )]
+    pub reasoner_connector: Option<String>,
+}

--- a/src/bin/implementation/mod.rs
+++ b/src/bin/implementation/mod.rs
@@ -1,3 +1,4 @@
 pub mod eflint;
+pub mod interface;
 pub mod no_op;
 pub mod posix;

--- a/src/bin/no_op.rs
+++ b/src/bin/no_op.rs
@@ -3,13 +3,13 @@
 //! policy reasoner.
 use std::env;
 use std::fs::File;
-use std::net::SocketAddr;
 
 pub mod implementation;
 
 use clap::Parser;
 use error_trace::ErrorTrace as _;
 use humanlog::{DebugMode, HumanLogger};
+use implementation::interface::Arguments;
 use implementation::no_op::NoOpReasonerConnector;
 use log::{error, info};
 use policy_reasoner::auth::{JwtConfig, JwtResolver, KidResolver};
@@ -31,19 +31,6 @@ fn get_dauth_resolver() -> policy_reasoner::auth::JwtResolver<KidResolver> {
     let r = File::open("./examples/config/jwt_resolver.yaml").unwrap();
     let jwt_cfg: JwtConfig = serde_yaml::from_reader(r).unwrap();
     JwtResolver::new(jwt_cfg, kid_resolver).unwrap()
-}
-
-/***** ARGUMENTS *****/
-/// Defines the arguments for the `policy-reasoner` server.
-#[derive(Debug, Parser, Clone)]
-struct Arguments {
-    /// Whether to enable full debugging
-    #[clap(long, global = true, help = "If given, enables more verbose debugging.")]
-    trace: bool,
-
-    /// The address on which to bind ourselves.
-    #[clap(short, long, env, default_value = "127.0.0.1:3030", help = "The address on which to bind the server.")]
-    address: SocketAddr,
 }
 
 /***** PLUGINS *****/

--- a/src/bin/posix.rs
+++ b/src/bin/posix.rs
@@ -16,11 +16,11 @@ pub mod implementation;
 
 use std::env;
 use std::fs::File;
-use std::net::SocketAddr;
 
 use clap::Parser;
 use error_trace::ErrorTrace as _;
 use humanlog::{DebugMode, HumanLogger};
+use implementation::interface::Arguments;
 use implementation::posix;
 use log::{error, info};
 use policy_reasoner::auth::{JwtConfig, JwtResolver, KidResolver};
@@ -42,43 +42,6 @@ fn get_dauth_resolver() -> policy_reasoner::auth::JwtResolver<KidResolver> {
     let r = File::open("./examples/config/jwt_resolver.yaml").unwrap();
     let jwt_cfg: JwtConfig = serde_yaml::from_reader(r).unwrap();
     JwtResolver::new(jwt_cfg, kid_resolver).unwrap()
-}
-
-/***** ARGUMENTS *****/
-/// Defines the arguments for the `policy-reasoner` server.
-#[derive(Debug, Parser, Clone)]
-struct Arguments {
-    /// Whether to enable full debugging
-    #[clap(long, global = true, help = "If given, enables more verbose debugging.")]
-    trace: bool,
-
-    /// The address on which to bind ourselves.
-    #[clap(short, long, env, default_value = "127.0.0.1:3030", help = "The address on which to bind the server.")]
-    address: SocketAddr,
-
-    /// Shows the help menu for the state resolver.
-    #[clap(long, help = "If given, shows the possible arguments to pass to the state resolver plugin in '--state-resolver'.")]
-    help_state_resolver: bool,
-    /// Arguments specific to the state resolver.
-    #[clap(
-        short,
-        long,
-        env,
-        help = "Arguments to pass to the current state resolver plugin. To find which are possible, see '--help-state-resolver'."
-    )]
-    state_resolver:      Option<String>,
-
-    /// Shows the help menu for the reasoner connector.
-    #[clap(long, help = "If given, shows the possible arguments to pass to the reasoner connector plugin in '--reasoner-connector'.")]
-    help_reasoner_connector: bool,
-    /// Arguments specific to the state resolver.
-    #[clap(
-        short,
-        long,
-        env,
-        help = "Arguments to pass to the current reasoner connector plugin. To find which are possible, see '--help-reasoner-connector'."
-    )]
-    reasoner_connector:      Option<String>,
 }
 
 /***** PLUGINS *****/


### PR DESCRIPTION
When abstracting the reasoner. I simplified the interfaces to no_op and posix. However, doing so I broke an implicit API in the command line arguments between the different reasoners. This became apparent when I started using the reasoner in Brane.

I changed it by defining a common interface module and move the `Arguments` into there. This should allow Brane to switch between the reasoners based only on an argument in the dockerfile without changing the api usage.

Cargo fmt is failing now. This PR is formatted in the same style as the main branch using nightly 1.82. I will reformat using 1.83 after it has been merged in order to avoid conflicts.
